### PR TITLE
Add all BinaryFormatter APIs to netstandard ref

### DIFF
--- a/extensions/remoting/remoting.cs
+++ b/extensions/remoting/remoting.cs
@@ -4,15 +4,6 @@ APIs removed/broken by this factoring:
     {
 //REMOTING        public virtual System.Runtime.Remoting.ObjRef CreateObjRef(System.Type requestedType) { throw null; }
     }
-    public sealed partial class BinaryFormatter :
-//REMOTING System.Runtime.Remoting.Messaging.IRemotingFormatter
-    {
-//REMOTING        public object Deserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
-//REMOTING        public object DeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
-//REMOTING        public void Serialize(System.IO.Stream serializationStream, object graph, System.Runtime.Remoting.Messaging.Header[] headers) { }
-//REMOTING        public object UnsafeDeserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
-//REMOTING        public object UnsafeDeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
-    }
     public sealed partial class Thread : System.Runtime.ConstrainedExecution.CriticalFinalizerObject
     {
 //REMOTING        public static System.Runtime.Remoting.Contexts.Context CurrentContext { get { throw null; } }
@@ -690,23 +681,8 @@ namespace System.Runtime.Remoting.Messaging
         public ConstructionResponse(System.Runtime.Remoting.Messaging.Header[] h, System.Runtime.Remoting.Messaging.IMethodCallMessage mcm) : base (default(System.Runtime.Remoting.Messaging.Header[]), default(System.Runtime.Remoting.Messaging.IMethodCallMessage)) { }
         public override System.Collections.IDictionary Properties { get { throw null; } }
     }
-    public partial class Header
-    {
-        public string HeaderNamespace;
-        public bool MustUnderstand;
-        public string Name;
-        public object Value;
-        public Header(string _Name, object _Value) { }
-        public Header(string _Name, object _Value, bool _MustUnderstand) { }
-        public Header(string _Name, object _Value, bool _MustUnderstand, string _HeaderNamespace) { }
-    }
-    public delegate object HeaderHandler(System.Runtime.Remoting.Messaging.Header[] headers);
     public partial interface ILogicalThreadAffinative
     {
-    }
-    public partial interface IMessage
-    {
-        System.Collections.IDictionary Properties { get; }
     }
     public partial interface IMessageCtrl
     {
@@ -717,27 +693,6 @@ namespace System.Runtime.Remoting.Messaging
         System.Runtime.Remoting.Messaging.IMessageSink NextSink { get; }
         System.Runtime.Remoting.Messaging.IMessageCtrl AsyncProcessMessage(System.Runtime.Remoting.Messaging.IMessage msg, System.Runtime.Remoting.Messaging.IMessageSink replySink);
         System.Runtime.Remoting.Messaging.IMessage SyncProcessMessage(System.Runtime.Remoting.Messaging.IMessage msg);
-    }
-    public partial interface IMethodCallMessage : System.Runtime.Remoting.Messaging.IMessage, System.Runtime.Remoting.Messaging.IMethodMessage
-    {
-        int InArgCount { get; }
-        object[] InArgs { get; }
-        object GetInArg(int argNum);
-        string GetInArgName(int index);
-    }
-    public partial interface IMethodMessage : System.Runtime.Remoting.Messaging.IMessage
-    {
-        int ArgCount { get; }
-        object[] Args { get; }
-        bool HasVarArgs { get; }
-        System.Runtime.Remoting.Messaging.LogicalCallContext LogicalCallContext { get; }
-        System.Reflection.MethodBase MethodBase { get; }
-        string MethodName { get; }
-        object MethodSignature { get; }
-        string TypeName { get; }
-        string Uri { get; }
-        object GetArg(int argNum);
-        string GetArgName(int index);
     }
     public partial interface IMethodReturnMessage : System.Runtime.Remoting.Messaging.IMessage, System.Runtime.Remoting.Messaging.IMethodMessage
     {
@@ -752,21 +707,6 @@ namespace System.Runtime.Remoting.Messaging
     {
         protected System.Runtime.Remoting.Messaging.IMessage WrappedMessage;
         public InternalMessageWrapper(System.Runtime.Remoting.Messaging.IMessage msg) { }
-    }
-    public partial interface IRemotingFormatter : System.Runtime.Serialization.IFormatter
-    {
-        object Deserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler);
-        void Serialize(System.IO.Stream serializationStream, object graph, System.Runtime.Remoting.Messaging.Header[] headers);
-    }
-    public sealed partial class LogicalCallContext : System.ICloneable, System.Runtime.Serialization.ISerializable
-    {
-        internal LogicalCallContext() { }
-        public bool HasInfo { get { throw null; } }
-        public object Clone() { throw null; }
-        public void FreeNamedDataSlot(string name) { }
-        public object GetData(string name) { throw null; }
-        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public void SetData(string name, object data) { }
     }
     public delegate bool MessageSurrogateFilter(string key, object value);
     [System.CLSCompliantAttribute(false)]

--- a/netstandard/ref/mscorlib.cs
+++ b/netstandard/ref/mscorlib.cs
@@ -11645,6 +11645,60 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public WriteOnlyArrayAttribute() { }
     }
 }
+namespace System.Runtime.Remoting.Messaging
+{
+    public partial class Header
+    {
+        public string HeaderNamespace;
+        public bool MustUnderstand;
+        public string Name;
+        public object Value;
+        public Header(string _Name, object _Value) { }
+        public Header(string _Name, object _Value, bool _MustUnderstand) { }
+        public Header(string _Name, object _Value, bool _MustUnderstand, string _HeaderNamespace) { }
+    }
+    public delegate object HeaderHandler(System.Runtime.Remoting.Messaging.Header[] headers);
+    public partial interface IMessage
+    {
+        System.Collections.IDictionary Properties { get; }
+    }
+    public partial interface IMethodCallMessage : System.Runtime.Remoting.Messaging.IMessage, System.Runtime.Remoting.Messaging.IMethodMessage
+    {
+        int InArgCount { get; }
+        object[] InArgs { get; }
+        object GetInArg(int argNum);
+        string GetInArgName(int index);
+    }
+    public partial interface IMethodMessage : System.Runtime.Remoting.Messaging.IMessage
+    {
+        int ArgCount { get; }
+        object[] Args { get; }
+        bool HasVarArgs { get; }
+        System.Runtime.Remoting.Messaging.LogicalCallContext LogicalCallContext { get; }
+        System.Reflection.MethodBase MethodBase { get; }
+        string MethodName { get; }
+        object MethodSignature { get; }
+        string TypeName { get; }
+        string Uri { get; }
+        object GetArg(int argNum);
+        string GetArgName(int index);
+    }
+    public partial interface IRemotingFormatter : System.Runtime.Serialization.IFormatter
+    {
+        object Deserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler);
+        void Serialize(System.IO.Stream serializationStream, object graph, System.Runtime.Remoting.Messaging.Header[] headers);
+    }
+    public sealed partial class LogicalCallContext : System.ICloneable, System.Runtime.Serialization.ISerializable
+    {
+        internal LogicalCallContext() { }
+        public bool HasInfo { get { throw null; } }
+        public object Clone() { throw null; }
+        public void FreeNamedDataSlot(string name) { }
+        public object GetData(string name) { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public void SetData(string name, object data) { }
+    }
+}
 namespace System.Runtime.Serialization
 {
     [System.CLSCompliantAttribute(false)]
@@ -11977,7 +12031,7 @@ namespace System.Runtime.Serialization.Formatters
 }
 namespace System.Runtime.Serialization.Formatters.Binary
 {
-    public sealed partial class BinaryFormatter : /*System.Runtime.Remoting.Messaging.IRemotingFormatter,*/ System.Runtime.Serialization.IFormatter
+    public sealed partial class BinaryFormatter : System.Runtime.Remoting.Messaging.IRemotingFormatter, System.Runtime.Serialization.IFormatter
     {
         public BinaryFormatter() { }
         public BinaryFormatter(System.Runtime.Serialization.ISurrogateSelector selector, System.Runtime.Serialization.StreamingContext context) { }
@@ -11988,12 +12042,12 @@ namespace System.Runtime.Serialization.Formatters.Binary
         public System.Runtime.Serialization.ISurrogateSelector SurrogateSelector { get { throw null; } set { } }
         public System.Runtime.Serialization.Formatters.FormatterTypeStyle TypeFormat { get { throw null; } set { } }
         public object Deserialize(System.IO.Stream serializationStream) { throw null; }
-//REMOTING        public object Deserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
-//REMOTING        public object DeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
+        public object Deserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
+        public object DeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
         public void Serialize(System.IO.Stream serializationStream, object graph) { }
-//REMOTING        public void Serialize(System.IO.Stream serializationStream, object graph, System.Runtime.Remoting.Messaging.Header[] headers) { }
-//REMOTING        public object UnsafeDeserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
-//REMOTING        public object UnsafeDeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
+        public void Serialize(System.IO.Stream serializationStream, object graph, System.Runtime.Remoting.Messaging.Header[] headers) { }
+        public object UnsafeDeserialize(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) { throw null; }
+        public object UnsafeDeserializeMethodResponse(System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) { throw null; }
     }
 }
 namespace System.Runtime.Versioning

--- a/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
@@ -525,6 +525,7 @@ TypesMustExist : Type 'System.Runtime.Serialization.ImportOptions' does not exis
 MembersMustExist : Member 'System.Runtime.Serialization.XmlSerializableServices.AddDefaultSchema(System.Xml.Schema.XmlSchemaSet, System.Xml.XmlQualifiedName)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.XsdDataContractExporter' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.XsdDataContractImporter' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.Serialization.Formatters.Binary.BinaryFormatter' does not implement interface 'System.Runtime.Remoting.Messaging.IRemotingFormatter' in the implementation but it does in the contract.
 TypesMustExist : Type 'System.Security.ManifestKinds' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.SecurityCriticalAttribute..ctor(System.Security.SecurityCriticalScope)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.SecurityCriticalAttribute.Scope.get()' does not exist in the implementation but it does exist in the contract.
@@ -624,4 +625,4 @@ MembersMustExist : Member 'System.Xml.Xsl.XslCompiledTransform.Load(System.Refle
 MembersMustExist : Member 'System.Xml.Xsl.XslCompiledTransform.Load(System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Xml.Xsl.XslCompiledTransform.TemporaryFiles.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Xml.Xsl.XslCompiledTransform.Transform(System.Xml.XPath.IXPathNavigable, System.Xml.Xsl.XsltArgumentList, System.Xml.XmlWriter, System.Xml.XmlResolver)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 625
+Total Issues: 626


### PR DESCRIPTION
Expose all the APIs in BinaryFormatter along with the full
closure. This adds a number of remoting interfaces.
