### PR TITLE
Scrubbing mscorlib.cs and move COM interop types into interop.cs

### DIFF
--- a/extensions/interop/interop.cs
+++ b/extensions/interop/interop.cs
@@ -98,6 +98,18 @@ namespace System.Runtime.DesignerServices
 }
 namespace System.Runtime.InteropServices
 {
+    [System.FlagsAttribute]
+    public enum AssemblyRegistrationFlags
+    {
+        None = 0,
+        SetCodeBase = 1,
+    }             
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1029), Inherited=false)]
+    public sealed partial class AutomationProxyAttribute : System.Attribute
+    {
+        public AutomationProxyAttribute(bool val) { }
+        public bool Value { get { throw null; } }
+    }             
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.BIND_OPTS instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct BIND_OPTS
@@ -132,10 +144,35 @@ namespace System.Runtime.InteropServices
         CC_STDCALL = 4,
         CC_SYSCALL = 6,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), Inherited=false)]
-    public sealed partial class ComImportAttribute : System.Attribute
+    [System.AttributeUsageAttribute((System.AttributeTargets)(10624), Inherited=false)]
+    public sealed partial class ComAliasNameAttribute : System.Attribute
     {
-        public ComImportAttribute() { }
+        public ComAliasNameAttribute(string alias) { }
+        public string Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
+    public sealed partial class ComCompatibleVersionAttribute : System.Attribute
+    {
+        public ComCompatibleVersionAttribute(int major, int minor, int build, int revision) { }
+        public int BuildNumber { get { throw null; } }
+        public int MajorVersion { get { throw null; } }
+        public int MinorVersion { get { throw null; } }
+        public int RevisionNumber { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=false)]
+    public sealed partial class ComConversionLossAttribute : System.Attribute
+    {
+        public ComConversionLossAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
+    public sealed partial class ComRegisterFunctionAttribute : System.Attribute
+    {
+        public ComRegisterFunctionAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
+    public sealed partial class ComUnregisterFunctionAttribute : System.Attribute
+    {
+        public ComUnregisterFunctionAttribute() { }
     }
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.CONNECTDATA instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -153,11 +190,6 @@ namespace System.Runtime.InteropServices
         DESCKIND_NONE = 0,
         DESCKIND_TYPECOMP = 3,
         DESCKIND_VARDESC = 2,
-    }
-    public sealed partial class DispatchWrapper
-    {
-        public DispatchWrapper(object obj) { }
-        public object WrappedObject { get { throw null; } }
     }
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.DISPPARAMS instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -183,13 +215,6 @@ namespace System.Runtime.InteropServices
             public System.Runtime.InteropServices.PARAMDESC paramdesc;
         }
     }
-    public sealed partial class ErrorWrapper
-    {
-        public ErrorWrapper(System.Exception e) { }
-        public ErrorWrapper(int errorCode) { }
-        public ErrorWrapper(object errorCode) { }
-        public int ErrorCode { get { throw null; } }
-    }
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.EXCEPINFO instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EXCEPINFO
@@ -203,6 +228,17 @@ namespace System.Runtime.InteropServices
         public short wCode;
         public short wReserved;
     }
+    public enum ExporterEventKind
+    {
+        ERROR_REFTOINVALIDASSEMBLY = 2,
+        NOTIF_CONVERTWARNING = 1,
+        NOTIF_TYPECONVERTED = 0,
+    }
+    public sealed partial class ExtensibleClassFactory
+    {
+        internal ExtensibleClassFactory() { }
+        public static void RegisterObjectCreationCallback(System.Runtime.InteropServices.ObjectCreationDelegate callback) { }
+    }      
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.FILETIME instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct FILETIME
@@ -253,13 +289,22 @@ namespace System.Runtime.InteropServices
         FUNC_PUREVIRTUAL = 1,
         FUNC_STATIC = 3,
         FUNC_VIRTUAL = 0,
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    public sealed partial class ImportedFromTypeLibAttribute : System.Attribute
+    }    
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5), Inherited=false)]
+    [System.ObsoleteAttribute("This attribute is deprecated and will be removed in a future version.", false)]
+    public sealed partial class IDispatchImplAttribute : System.Attribute
     {
-        public ImportedFromTypeLibAttribute(string tlbFile) { }
-        public string Value { get { throw null; } }
+        public IDispatchImplAttribute(short implType) { }
+        public IDispatchImplAttribute(System.Runtime.InteropServices.IDispatchImplType implType) { }
+        public System.Runtime.InteropServices.IDispatchImplType Value { get { throw null; } }
     }
+    [System.ObsoleteAttribute("The IDispatchImplAttribute is deprecated.", false)]
+    public enum IDispatchImplType
+    {
+        CompatibleImpl = 2,
+        InternalImpl = 1,
+        SystemDefinedImpl = 0,
+    }      
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.IDLDESC instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct IDLDESC
@@ -286,6 +331,12 @@ namespace System.Runtime.InteropServices
         IMPLTYPEFLAG_FRESTRICTED = 4,
         IMPLTYPEFLAG_FSOURCE = 2,
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
+    public sealed partial class ImportedFromTypeLibAttribute : System.Attribute
+    {
+        public ImportedFromTypeLibAttribute(string tlbFile) { }
+        public string Value { get { throw null; } }
+    }                           
     public enum ImporterEventKind
     {
         ERROR_REFTOINVALIDTYPELIB = 2,
@@ -332,6 +383,12 @@ namespace System.Runtime.InteropServices
         void ReportEvent(System.Runtime.InteropServices.ImporterEventKind eventKind, int eventCode, string eventMsg);
         System.Reflection.Assembly ResolveRef(object typeLib);
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
+    public sealed partial class LCIDConversionAttribute : System.Attribute
+    {
+        public LCIDConversionAttribute(int lcid) { }
+        public int Value { get { throw null; } }
+    }    
     [System.FlagsAttribute]
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.LIBFLAGS instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     public enum LIBFLAGS : short
@@ -341,6 +398,13 @@ namespace System.Runtime.InteropServices
         LIBFLAG_FHIDDEN = (short)4,
         LIBFLAG_FRESTRICTED = (short)1,
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
+    public sealed partial class ManagedToNativeComInteropStubAttribute : System.Attribute
+    {
+        public ManagedToNativeComInteropStubAttribute(System.Type classType, string methodName) { }
+        public System.Type ClassType { get { throw null; } }
+        public string MethodName { get { throw null; } }
+    }    
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.PARAMDESC instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct PARAMDESC
@@ -361,6 +425,50 @@ namespace System.Runtime.InteropServices
         PARAMFLAG_FRETVAL = (short)8,
         PARAMFLAG_NONE = (short)0,
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false, AllowMultiple=true)]
+    public sealed partial class PrimaryInteropAssemblyAttribute : System.Attribute
+    {
+        public PrimaryInteropAssemblyAttribute(int major, int minor) { }
+        public int MajorVersion { get { throw null; } }
+        public int MinorVersion { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false)]
+    public sealed partial class ProgIdAttribute : System.Attribute
+    {
+        public ProgIdAttribute(string progId) { }
+        public string Value { get { throw null; } }
+    }
+    [System.FlagsAttribute]
+    public enum RegistrationClassContext
+    {
+        DisableActivateAsActivator = 32768,
+        EnableActivateAsActivator = 65536,
+        EnableCodeDownload = 8192,
+        FromDefaultContext = 131072,
+        InProcessHandler = 2,
+        InProcessHandler16 = 32,
+        InProcessServer = 1,
+        InProcessServer16 = 8,
+        LocalServer = 4,
+        NoCodeDownload = 1024,
+        NoCustomMarshal = 4096,
+        NoFailureLog = 16384,
+        RemoteServer = 16,
+        Reserved1 = 64,
+        Reserved2 = 128,
+        Reserved3 = 256,
+        Reserved4 = 512,
+        Reserved5 = 2048,
+    }
+    [System.FlagsAttribute]
+    public enum RegistrationConnectionType
+    {
+        MultipleUse = 1,
+        MultiSeparate = 2,
+        SingleUse = 0,
+        Surrogate = 8,
+        Suspended = 4,
+    }     
     public partial class RegistrationServices : System.Runtime.InteropServices.IRegistrationServices
     {
         public RegistrationServices() { }
@@ -374,7 +482,13 @@ namespace System.Runtime.InteropServices
         public virtual bool TypeRequiresRegistration(System.Type type) { throw null; }
         public virtual bool UnregisterAssembly(System.Reflection.Assembly assembly) { throw null; }
         public virtual void UnregisterTypeForComClients(int cookie) { }
-    }
+    }    
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
+    [System.ObsoleteAttribute("This attribute has been deprecated.  Application Domains no longer respect Activation Context boundaries in IDispatch calls.", false)]
+    public sealed partial class SetWin32ContextInIDispatchAttribute : System.Attribute
+    {
+        public SetWin32ContextInIDispatchAttribute() { }
+    }    
     public partial class StandardOleMarshalObject : System.MarshalByRefObject
     {
         protected StandardOleMarshalObject() { }
@@ -453,6 +567,19 @@ namespace System.Runtime.InteropServices
         TYPEFLAG_FRESTRICTED = (short)512,
         TYPEFLAG_FREVERSEBIND = (short)8192,
     }
+    [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.TYPEKIND instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
+    public enum TYPEKIND
+    {
+        TKIND_ALIAS = 6,
+        TKIND_COCLASS = 5,
+        TKIND_DISPATCH = 4,
+        TKIND_ENUM = 0,
+        TKIND_INTERFACE = 3,
+        TKIND_MAX = 8,
+        TKIND_MODULE = 2,
+        TKIND_RECORD = 1,
+        TKIND_UNION = 7,
+    }    
     [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.TYPELIBATTR instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TYPELIBATTR
@@ -1265,18 +1392,6 @@ namespace System.Runtime.InteropServices.ComTypes
         TYPEFLAG_FRESTRICTED = (short)512,
         TYPEFLAG_FREVERSEBIND = (short)8192,
     }
-    public enum TYPEKIND
-    {
-        TKIND_ALIAS = 6,
-        TKIND_COCLASS = 5,
-        TKIND_DISPATCH = 4,
-        TKIND_ENUM = 0,
-        TKIND_INTERFACE = 3,
-        TKIND_MAX = 8,
-        TKIND_MODULE = 2,
-        TKIND_RECORD = 1,
-        TKIND_UNION = 7,
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TYPELIBATTR
     {
@@ -1425,5 +1540,113 @@ namespace System.Runtime.InteropServices.ComTypes
         TYMED_ISTREAM = 4,
         TYMED_MFPICT = 32,
         TYMED_NULL = 0,
+    }
+    public enum TYPEKIND
+    {
+        TKIND_ALIAS = 6,
+        TKIND_COCLASS = 5,
+        TKIND_DISPATCH = 4,
+        TKIND_ENUM = 0,
+        TKIND_INTERFACE = 3,
+        TKIND_MAX = 8,
+        TKIND_MODULE = 2,
+        TKIND_RECORD = 1,
+        TKIND_UNION = 7,
+    }
+}
+namespace System.Runtime.InteropServices.Expando
+{
+    public partial interface IExpando : System.Reflection.IReflect
+    {
+        System.Reflection.FieldInfo AddField(string name);
+        System.Reflection.MethodInfo AddMethod(string name, System.Delegate method);
+        System.Reflection.PropertyInfo AddProperty(string name);
+        void RemoveMember(System.Reflection.MemberInfo m);
+    }
+}
+namespace System.Runtime.InteropServices.WindowsRuntime
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), AllowMultiple=false, Inherited=false)]
+    public sealed partial class DefaultInterfaceAttribute : System.Attribute
+    {
+        public DefaultInterfaceAttribute(System.Type defaultInterface) { }
+        public System.Type DefaultInterface { get { throw null; } }
+    }
+    public partial class DesignerNamespaceResolveEventArgs : System.EventArgs
+    {
+        public DesignerNamespaceResolveEventArgs(string namespaceName) { }
+        public string NamespaceName { get { throw null; } }
+        public System.Collections.ObjectModel.Collection<string> ResolvedAssemblyFiles { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct EventRegistrationToken
+    {
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken left, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken right) { throw null; }
+        public static bool operator !=(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken left, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken right) { throw null; }
+    }
+    public sealed partial class EventRegistrationTokenTable<T> where T : class
+    {
+        public EventRegistrationTokenTable() { }
+        public T InvocationList { get { throw null; } set { } }
+        public System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken AddEventHandler(T handler) { throw null; }
+        public static System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> GetOrCreateEventRegistrationTokenTable(ref System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> refEventTable) { throw null; }
+        public void RemoveEventHandler(T handler) { }
+        public void RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken token) { }
+    }
+    public partial interface IActivationFactory
+    {
+        object ActivateInstance();
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), Inherited=false, AllowMultiple=true)]
+    public sealed partial class InterfaceImplementedInVersionAttribute : System.Attribute
+    {
+        public InterfaceImplementedInVersionAttribute(System.Type interfaceType, byte majorVersion, byte minorVersion, byte buildVersion, byte revisionVersion) { }
+        public byte BuildVersion { get { throw null; } }
+        public System.Type InterfaceType { get { throw null; } }
+        public byte MajorVersion { get { throw null; } }
+        public byte MinorVersion { get { throw null; } }
+        public byte RevisionVersion { get { throw null; } }
+    }
+    public partial class NamespaceResolveEventArgs : System.EventArgs
+    {
+        public NamespaceResolveEventArgs(string namespaceName, System.Reflection.Assembly requestingAssembly) { }
+        public string NamespaceName { get { throw null; } }
+        public System.Reflection.Assembly RequestingAssembly { get { throw null; } }
+        public System.Collections.ObjectModel.Collection<System.Reflection.Assembly> ResolvedAssemblies { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false, AllowMultiple=false)]
+    public sealed partial class ReadOnlyArrayAttribute : System.Attribute
+    {
+        public ReadOnlyArrayAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(12288), AllowMultiple=false, Inherited=false)]
+    public sealed partial class ReturnValueNameAttribute : System.Attribute
+    {
+        public ReturnValueNameAttribute(string name) { }
+        public string Name { get { throw null; } }
+    }
+    public static partial class WindowsRuntimeMarshal
+    {
+        public static void AddEventHandler<T>(System.Func<T, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> addMethod, System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
+        public static void FreeHString(System.IntPtr ptr) { }
+        public static System.Runtime.InteropServices.WindowsRuntime.IActivationFactory GetActivationFactory(System.Type type) { throw null; }
+        public static string PtrToStringHString(System.IntPtr ptr) { throw null; }
+        public static void RemoveAllEventHandlers(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod) { }
+        public static void RemoveEventHandler<T>(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
+        public static System.IntPtr StringToHString(string s) { throw null; }
+    }
+    public static partial class WindowsRuntimeMetadata
+    {
+        public static event System.EventHandler<System.Runtime.InteropServices.WindowsRuntime.DesignerNamespaceResolveEventArgs> DesignerNamespaceResolve { add { } remove { } }
+        public static event System.EventHandler<System.Runtime.InteropServices.WindowsRuntime.NamespaceResolveEventArgs> ReflectionOnlyNamespaceResolve { add { } remove { } }
+        public static System.Collections.Generic.IEnumerable<string> ResolveNamespace(string namespaceName, System.Collections.Generic.IEnumerable<string> packageGraphFilePaths) { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> ResolveNamespace(string namespaceName, string windowsSdkFilePath, System.Collections.Generic.IEnumerable<string> packageGraphFilePaths) { throw null; }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false, AllowMultiple=false)]
+    public sealed partial class WriteOnlyArrayAttribute : System.Attribute
+    {
+        public WriteOnlyArrayAttribute() { }
     }
 }

--- a/extensions/remoting/remoting.cs
+++ b/extensions/remoting/remoting.cs
@@ -217,6 +217,13 @@ namespace System.Runtime.Hosting
         protected static System.Runtime.Remoting.ObjectHandle CreateInstanceHelper(System.AppDomainSetup adSetup) { throw null; }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial interface ICustomFactory
+    {
+        System.MarshalByRefObject CreateInstance(System.Type serverType);
+    }    
+}
 namespace System.Runtime.Remoting
 {
     public partial class ActivatedClientTypeEntry : System.Runtime.Remoting.TypeEntry

--- a/netstandard/ref/mscorlib.cs
+++ b/netstandard/ref/mscorlib.cs
@@ -9356,18 +9356,6 @@ namespace System.Runtime.InteropServices
         public static bool operator ==(System.Runtime.InteropServices.ArrayWithOffset a, System.Runtime.InteropServices.ArrayWithOffset b) { throw null; }
         public static bool operator !=(System.Runtime.InteropServices.ArrayWithOffset a, System.Runtime.InteropServices.ArrayWithOffset b) { throw null; }
     }
-    [System.FlagsAttribute]
-    public enum AssemblyRegistrationFlags
-    {
-        None = 0,
-        SetCodeBase = 1,
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1029), Inherited=false)]
-    public sealed partial class AutomationProxyAttribute : System.Attribute
-    {
-        public AutomationProxyAttribute(bool val) { }
-        public bool Value { get { throw null; } }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1037), Inherited=false)]
     public sealed partial class BestFitMappingAttribute : System.Attribute
     {
@@ -9380,7 +9368,7 @@ namespace System.Runtime.InteropServices
         public BStrWrapper(object value) { }
         public BStrWrapper(string value) { }
         public string WrappedObject { get { throw null; } }
-    }
+    }                  
     public enum CallingConvention
     {
         Cdecl = 2,
@@ -9395,7 +9383,7 @@ namespace System.Runtime.InteropServices
         Auto = 4,
         None = 1,
         Unicode = 3,
-    }
+    }    
     [System.AttributeUsageAttribute((System.AttributeTargets)(5), Inherited=false)]
     public sealed partial class ClassInterfaceAttribute : System.Attribute
     {
@@ -9414,26 +9402,6 @@ namespace System.Runtime.InteropServices
     {
         public CoClassAttribute(System.Type coClass) { }
         public System.Type CoClass { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(10624), Inherited=false)]
-    public sealed partial class ComAliasNameAttribute : System.Attribute
-    {
-        public ComAliasNameAttribute(string alias) { }
-        public string Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    public sealed partial class ComCompatibleVersionAttribute : System.Attribute
-    {
-        public ComCompatibleVersionAttribute(int major, int minor, int build, int revision) { }
-        public int BuildNumber { get { throw null; } }
-        public int MajorVersion { get { throw null; } }
-        public int MinorVersion { get { throw null; } }
-        public int RevisionNumber { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=false)]
-    public sealed partial class ComConversionLossAttribute : System.Attribute
-    {
-        public ComConversionLossAttribute() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false)]
     public sealed partial class ComDefaultInterfaceAttribute : System.Attribute
@@ -9462,24 +9430,24 @@ namespace System.Runtime.InteropServices
         public COMException(string message, int errorCode) { }
         public override string ToString() { throw null; }
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), Inherited=false)]
+    public sealed partial class ComImportAttribute : System.Attribute
+    {
+        public ComImportAttribute() { }
+    }    
     public enum ComInterfaceType
     {
         InterfaceIsDual = 0,
         InterfaceIsIDispatch = 2,
         InterfaceIsIInspectable = 3,
         InterfaceIsIUnknown = 1,
-    }
+    }    
     public enum ComMemberType
     {
         Method = 0,
         PropGet = 1,
         PropSet = 2,
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    public sealed partial class ComRegisterFunctionAttribute : System.Attribute
-    {
-        public ComRegisterFunctionAttribute() { }
-    }
+    }     
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=true)]
     public sealed partial class ComSourceInterfacesAttribute : System.Attribute
     {
@@ -9489,11 +9457,6 @@ namespace System.Runtime.InteropServices
         public ComSourceInterfacesAttribute(System.Type sourceInterface1, System.Type sourceInterface2, System.Type sourceInterface3) { }
         public ComSourceInterfacesAttribute(System.Type sourceInterface1, System.Type sourceInterface2, System.Type sourceInterface3, System.Type sourceInterface4) { }
         public string Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    public sealed partial class ComUnregisterFunctionAttribute : System.Attribute
-    {
-        public ComUnregisterFunctionAttribute() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(5597), Inherited=false)]
     public sealed partial class ComVisibleAttribute : System.Attribute
@@ -9531,7 +9494,7 @@ namespace System.Runtime.InteropServices
         Failed = 2,
         Handled = 0,
         NotHandled = 1,
-    }
+    }                
     [System.AttributeUsageAttribute((System.AttributeTargets)(2), Inherited=false)]
     public sealed partial class DefaultCharSetAttribute : System.Attribute
     {
@@ -9543,6 +9506,11 @@ namespace System.Runtime.InteropServices
     {
         public DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath paths) { }
         public System.Runtime.InteropServices.DllImportSearchPath Paths { get { throw null; } }
+    }
+    public sealed partial class DispatchWrapper
+    {
+        public DispatchWrapper(object obj) { }
+        public object WrappedObject { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(960), Inherited=false)]
     public sealed partial class DispIdAttribute : System.Attribute
@@ -9575,16 +9543,12 @@ namespace System.Runtime.InteropServices
         UseDllDirectoryForDependencies = 256,
         UserDirectories = 1024,
     }
-    public enum ExporterEventKind
+    public sealed partial class ErrorWrapper
     {
-        ERROR_REFTOINVALIDASSEMBLY = 2,
-        NOTIF_CONVERTWARNING = 1,
-        NOTIF_TYPECONVERTED = 0,
-    }
-    public sealed partial class ExtensibleClassFactory
-    {
-        internal ExtensibleClassFactory() { }
-        public static void RegisterObjectCreationCallback(System.Runtime.InteropServices.ObjectCreationDelegate callback) { }
+        public ErrorWrapper(System.Exception e) { }
+        public ErrorWrapper(int errorCode) { }
+        public ErrorWrapper(object errorCode) { }
+        public int ErrorCode { get { throw null; } }
     }
     public partial class ExternalException : System.SystemException
     {
@@ -9646,10 +9610,6 @@ namespace System.Runtime.InteropServices
     {
         object GetUnderlyingObject();
     }
-    public partial interface ICustomFactory
-    {
-        System.MarshalByRefObject CreateInstance(System.Type serverType);
-    }
     public partial interface ICustomMarshaler
     {
         void CleanUpManagedData(object ManagedObj);
@@ -9661,21 +9621,6 @@ namespace System.Runtime.InteropServices
     public partial interface ICustomQueryInterface
     {
         System.Runtime.InteropServices.CustomQueryInterfaceResult GetInterface(ref System.Guid iid, out System.IntPtr ppv);
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5), Inherited=false)]
-    [System.ObsoleteAttribute("This attribute is deprecated and will be removed in a future version.", false)]
-    public sealed partial class IDispatchImplAttribute : System.Attribute
-    {
-        public IDispatchImplAttribute(short implType) { }
-        public IDispatchImplAttribute(System.Runtime.InteropServices.IDispatchImplType implType) { }
-        public System.Runtime.InteropServices.IDispatchImplType Value { get { throw null; } }
-    }
-    [System.ObsoleteAttribute("The IDispatchImplAttribute is deprecated.", false)]
-    public enum IDispatchImplType
-    {
-        CompatibleImpl = 2,
-        InternalImpl = 1,
-        SystemDefinedImpl = 0,
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class InAttribute : System.Attribute
@@ -9702,25 +9647,12 @@ namespace System.Runtime.InteropServices
         protected InvalidOleVariantTypeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidOleVariantTypeException(string message) { }
         public InvalidOleVariantTypeException(string message, System.Exception inner) { }
-    }
+    }     
     public enum LayoutKind
     {
         Auto = 3,
         Explicit = 2,
         Sequential = 0,
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    public sealed partial class LCIDConversionAttribute : System.Attribute
-    {
-        public LCIDConversionAttribute(int lcid) { }
-        public int Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
-    public sealed partial class ManagedToNativeComInteropStubAttribute : System.Attribute
-    {
-        public ManagedToNativeComInteropStubAttribute(System.Type classType, string methodName) { }
-        public System.Type ClassType { get { throw null; } }
-        public string MethodName { get { throw null; } }
     }
     public static partial class Marshal
     {
@@ -9946,50 +9878,6 @@ namespace System.Runtime.InteropServices
     {
         public PreserveSigAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false, AllowMultiple=true)]
-    public sealed partial class PrimaryInteropAssemblyAttribute : System.Attribute
-    {
-        public PrimaryInteropAssemblyAttribute(int major, int minor) { }
-        public int MajorVersion { get { throw null; } }
-        public int MinorVersion { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false)]
-    public sealed partial class ProgIdAttribute : System.Attribute
-    {
-        public ProgIdAttribute(string progId) { }
-        public string Value { get { throw null; } }
-    }
-    [System.FlagsAttribute]
-    public enum RegistrationClassContext
-    {
-        DisableActivateAsActivator = 32768,
-        EnableActivateAsActivator = 65536,
-        EnableCodeDownload = 8192,
-        FromDefaultContext = 131072,
-        InProcessHandler = 2,
-        InProcessHandler16 = 32,
-        InProcessServer = 1,
-        InProcessServer16 = 8,
-        LocalServer = 4,
-        NoCodeDownload = 1024,
-        NoCustomMarshal = 4096,
-        NoFailureLog = 16384,
-        RemoteServer = 16,
-        Reserved1 = 64,
-        Reserved2 = 128,
-        Reserved3 = 256,
-        Reserved4 = 512,
-        Reserved5 = 2048,
-    }
-    [System.FlagsAttribute]
-    public enum RegistrationConnectionType
-    {
-        MultipleUse = 1,
-        MultiSeparate = 2,
-        SingleUse = 0,
-        Surrogate = 8,
-        Suspended = 4,
-    }
     public static partial class RuntimeEnvironment
     {
         public static string SystemConfigurationFile { get { throw null; } }
@@ -10012,7 +9900,7 @@ namespace System.Runtime.InteropServices
         protected SafeArrayTypeMismatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public SafeArrayTypeMismatchException(string message) { }
         public SafeArrayTypeMismatchException(string message, System.Exception inner) { }
-    }
+    }    
     public abstract partial class SafeBuffer : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         protected SafeBuffer(bool ownsHandle) : base (default(bool)) { }
@@ -10060,13 +9948,7 @@ namespace System.Runtime.InteropServices
         public SEHException(string message) { }
         public SEHException(string message, System.Exception inner) { }
         public virtual bool CanResume() { throw null; }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    [System.ObsoleteAttribute("This attribute has been deprecated.  Application Domains no longer respect Activation Context boundaries in IDispatch calls.", false)]
-    public sealed partial class SetWin32ContextInIDispatchAttribute : System.Attribute
-    {
-        public SetWin32ContextInIDispatchAttribute() { }
-    }
+    }    
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false)]
     public sealed partial class StructLayoutAttribute : System.Attribute
     {
@@ -10084,19 +9966,6 @@ namespace System.Runtime.InteropServices
         public TypeIdentifierAttribute(string scope, string identifier) { }
         public string Identifier { get { throw null; } }
         public string Scope { get { throw null; } }
-    }
-    [System.ObsoleteAttribute("Use System.Runtime.InteropServices.ComTypes.TYPEKIND instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
-    public enum TYPEKIND
-    {
-        TKIND_ALIAS = 6,
-        TKIND_COCLASS = 5,
-        TKIND_DISPATCH = 4,
-        TKIND_ENUM = 0,
-        TKIND_INTERFACE = 3,
-        TKIND_MAX = 8,
-        TKIND_MODULE = 2,
-        TKIND_RECORD = 1,
-        TKIND_UNION = 7,
     }
     public sealed partial class UnknownWrapper
     {
@@ -10205,102 +10074,7 @@ namespace System.Runtime.InteropServices
         public VariantWrapper(object obj) { }
         public object WrappedObject { get { throw null; } }
     }
-}
-namespace System.Runtime.InteropServices.Expando
-{
-    public partial interface IExpando : System.Reflection.IReflect
-    {
-        System.Reflection.FieldInfo AddField(string name);
-        System.Reflection.MethodInfo AddMethod(string name, System.Delegate method);
-        System.Reflection.PropertyInfo AddProperty(string name);
-        void RemoveMember(System.Reflection.MemberInfo m);
-    }
-}
-namespace System.Runtime.InteropServices.WindowsRuntime
-{
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), AllowMultiple=false, Inherited=false)]
-    public sealed partial class DefaultInterfaceAttribute : System.Attribute
-    {
-        public DefaultInterfaceAttribute(System.Type defaultInterface) { }
-        public System.Type DefaultInterface { get { throw null; } }
-    }
-    public partial class DesignerNamespaceResolveEventArgs : System.EventArgs
-    {
-        public DesignerNamespaceResolveEventArgs(string namespaceName) { }
-        public string NamespaceName { get { throw null; } }
-        public System.Collections.ObjectModel.Collection<string> ResolvedAssemblyFiles { get { throw null; } }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventRegistrationToken
-    {
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken left, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken right) { throw null; }
-        public static bool operator !=(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken left, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken right) { throw null; }
-    }
-    public sealed partial class EventRegistrationTokenTable<T> where T : class
-    {
-        public EventRegistrationTokenTable() { }
-        public T InvocationList { get { throw null; } set { } }
-        public System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken AddEventHandler(T handler) { throw null; }
-        public static System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> GetOrCreateEventRegistrationTokenTable(ref System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> refEventTable) { throw null; }
-        public void RemoveEventHandler(T handler) { }
-        public void RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken token) { }
-    }
-    public partial interface IActivationFactory
-    {
-        object ActivateInstance();
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), Inherited=false, AllowMultiple=true)]
-    public sealed partial class InterfaceImplementedInVersionAttribute : System.Attribute
-    {
-        public InterfaceImplementedInVersionAttribute(System.Type interfaceType, byte majorVersion, byte minorVersion, byte buildVersion, byte revisionVersion) { }
-        public byte BuildVersion { get { throw null; } }
-        public System.Type InterfaceType { get { throw null; } }
-        public byte MajorVersion { get { throw null; } }
-        public byte MinorVersion { get { throw null; } }
-        public byte RevisionVersion { get { throw null; } }
-    }
-    public partial class NamespaceResolveEventArgs : System.EventArgs
-    {
-        public NamespaceResolveEventArgs(string namespaceName, System.Reflection.Assembly requestingAssembly) { }
-        public string NamespaceName { get { throw null; } }
-        public System.Reflection.Assembly RequestingAssembly { get { throw null; } }
-        public System.Collections.ObjectModel.Collection<System.Reflection.Assembly> ResolvedAssemblies { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false, AllowMultiple=false)]
-    public sealed partial class ReadOnlyArrayAttribute : System.Attribute
-    {
-        public ReadOnlyArrayAttribute() { }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(12288), AllowMultiple=false, Inherited=false)]
-    public sealed partial class ReturnValueNameAttribute : System.Attribute
-    {
-        public ReturnValueNameAttribute(string name) { }
-        public string Name { get { throw null; } }
-    }
-    public static partial class WindowsRuntimeMarshal
-    {
-        public static void AddEventHandler<T>(System.Func<T, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> addMethod, System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
-        public static void FreeHString(System.IntPtr ptr) { }
-        public static System.Runtime.InteropServices.WindowsRuntime.IActivationFactory GetActivationFactory(System.Type type) { throw null; }
-        public static string PtrToStringHString(System.IntPtr ptr) { throw null; }
-        public static void RemoveAllEventHandlers(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod) { }
-        public static void RemoveEventHandler<T>(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
-        public static System.IntPtr StringToHString(string s) { throw null; }
-    }
-    public static partial class WindowsRuntimeMetadata
-    {
-        public static event System.EventHandler<System.Runtime.InteropServices.WindowsRuntime.DesignerNamespaceResolveEventArgs> DesignerNamespaceResolve { add { } remove { } }
-        public static event System.EventHandler<System.Runtime.InteropServices.WindowsRuntime.NamespaceResolveEventArgs> ReflectionOnlyNamespaceResolve { add { } remove { } }
-        public static System.Collections.Generic.IEnumerable<string> ResolveNamespace(string namespaceName, System.Collections.Generic.IEnumerable<string> packageGraphFilePaths) { throw null; }
-        public static System.Collections.Generic.IEnumerable<string> ResolveNamespace(string namespaceName, string windowsSdkFilePath, System.Collections.Generic.IEnumerable<string> packageGraphFilePaths) { throw null; }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false, AllowMultiple=false)]
-    public sealed partial class WriteOnlyArrayAttribute : System.Attribute
-    {
-        public WriteOnlyArrayAttribute() { }
-    }
+
 }
 namespace System.Runtime.Remoting
 {


### PR DESCRIPTION
This is the latest revision of the interop scrubbing (earlier version is https://github.com/dotnet/standard/pull/23 which is no longer valid because we made the repo public) 
I moved the interesting exception types back into mscorlib.cs and moved quite a few COM interop types back into mscorlib.cs as well since they are available in S.R.InteropServices
@weshaggard @danmosemsft @jkotas 
/cc @marek-safar @akoeplinger 