### PR TITLE
Generalize the JSON.NET case to any IL-library

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -160,6 +160,15 @@ with him rather than just building "another" JSON.NET. We want a strong
 ecosystem for .NET, but this can only happen if we embrace libraries based on
 merit, rather than by who wrote it. That's what open source is all about.
 
+## Why is XYZ not part of .NET Standard?
+
+As explained in the JSON.NET example above, there is a trade-off between adding
+components to .NET Standard and having components that are on top of .NET
+Standard and can be updated independently.
+
+Check out the [.NET Standard inclusion principles][netstandard-principles] to
+see how we approach this.
+
 ## Why do you include APIs that don't work everywhere?
 
 We generally don't include APIs in .NET Standard that don't work everywhere, and
@@ -229,5 +238,6 @@ it has some diagrams.
 [netstandard-analogy]: https://gist.github.com/davidfowl/8939f305567e1755412d6dc0b8baf1b7
 [netstandard-versions]: versions.md
 [netstandard-targeting]: versions.md#how-do-i-know-which-net-standard-version-i-should-target
+[netstandard-principles]: review-board/README.md#inclusion-principles
 [netstandard-461]: netstandard-20/README.md#net-framework-461-supporting-net-standard-20
 [issue]: https://github.com/dotnet/standard/issues/new

--- a/docs/review-board/README.md
+++ b/docs/review-board/README.md
@@ -16,3 +16,46 @@ and API drivers appear, the review board will expand accordingly.
 ## Reviews
 
 Decisions made by the review body will be made public and posted here.
+
+## Inclusion principles
+
+Not every .NET API needs (or even should be) part of .NET Standard.
+
+If a library is written in pure IL (for example C#, VB.NET, F# etc.), and
+targets .NET Standard, then it can run across all current and future .NET
+platforms with no code changes. The only requirement on the .NET platform is
+that it has to support at least that version of .NET Standard that the library
+was compiled for (or a higher version).
+
+Any modification to such a library, whether it's bug fixes, performance
+improvements or additional APIs, will also work across all these .NET platforms
+as well, so:
+
+* The library author has great flexibility to version and make releases on their
+  own cadence.
+* Consumers of that library have great choice on when they upgrade the version
+  of that library they are using.
+
+If the library is made a part of .NET Standard it can only version at the same
+cadence as the standard, so the update flexibility is much reduced.
+
+The following criteria helps us to identify APIs that can be a part of .NET
+Standard:
+
+* **Ubiqutous APIs**. APIs in the .NET Standard must be implemented by all .NET
+  platforms. Thus, we're only interested in standardizing APIs that are
+  universal in nature and thus should be available everywhere.
+
+* **Mature APIs**. APIs that are part of the .NET Standard can only be versioned
+  when the standard itself is versioned. Thus, we generally only standardize
+  APIs that are mature enough that they don't have to be updated frequently.
+
+* **Runtime-specific APIs**. If the APIs have to be implemented by the runtime,
+  they don't benefit from being libraries on top of .NET Standard. Good examples
+  of such APIs include primitive types, reflection, GC, and code-gen intrinsics
+  (SIMD).
+
+* **Widely-used APIs**. In order to enable a vibrant .NET ecosystem, it's
+  important to have a common vocabulary of types that library authors can rely
+  on. Thus, it's beneficial to add widely used APIs to the .NET Standard as it
+  simplifies building reusable libraries.


### PR DESCRIPTION
Based on @benaadams suggestion, I've updated the FAQ to explain which kind of libraries wouldn't benefit from being part of .NET Standard.

This fixes #66.