### PR TITLE
Two updates

### DIFF
--- a/netstandard/ref/mscorlib.cs
+++ b/netstandard/ref/mscorlib.cs
@@ -3234,6 +3234,7 @@ namespace System
         public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
         public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
     }
+    [System.ObsoleteAttribute("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]    
     public abstract partial class TimeZone
     {
         protected TimeZone() { }
@@ -12224,6 +12225,7 @@ namespace System.Security.Cryptography
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class IncrementalHash : System.IDisposable
     {
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }


### PR DESCRIPTION
1) Add internal ctor to IncrementalHash. It has no public constructor in the impl and contract, and this prevents that showing up in the diff with standard.

2) Add [Obsolete] which we already added in corefx.

@weshaggard 