### PR TITLE
Add license headers to .cs files

### DIFF
--- a/extensions/accesscontrols/accesscontrols.cs
+++ b/extensions/accesscontrols/accesscontrols.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/cas/cas.cs
+++ b/extensions/cas/cas.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 public sealed partial class AppDomain : System.MarshalByRefObject

--- a/extensions/codedom/codedom.cs
+++ b/extensions/codedom/codedom.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/crypto/crypto.cs
+++ b/extensions/crypto/crypto.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/eventing/eventing.cs
+++ b/extensions/eventing/eventing.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/eventlog/eventlog.cs
+++ b/extensions/eventlog/eventlog.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/interop/interop.cs
+++ b/extensions/interop/interop.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/misc/misc.cs
+++ b/extensions/misc/misc.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/mswin32/mswin32.cs
+++ b/extensions/mswin32/mswin32.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/perfcounters/perfcounters.cs
+++ b/extensions/perfcounters/perfcounters.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/reflection.emit/reflection.emit.cs
+++ b/extensions/reflection.emit/reflection.emit.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
     public sealed partial class AppDomain : System.MarshalByRefObject, System.Security.IEvidenceFactory

--- a/extensions/registry/registry.cs
+++ b/extensions/registry/registry.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/remoting/remoting.cs
+++ b/extensions/remoting/remoting.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
     public sealed partial class Activator

--- a/extensions/serialport/serialport.cs
+++ b/extensions/serialport/serialport.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/tracelisteners/tracelisteners.cs
+++ b/extensions/tracelisteners/tracelisteners.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/windowsidentity/windowsidentity.cs
+++ b/extensions/windowsidentity/windowsidentity.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/extensions/wmi/wmi.cs
+++ b/extensions/wmi/wmi.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 /*
 APIs removed/broken by this factoring:
 

--- a/netstandard/ref/System.Core.cs
+++ b/netstandard/ref/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/netstandard/ref/System.Data.cs
+++ b/netstandard/ref/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Data
 {
     public enum AcceptRejectRule

--- a/netstandard/ref/System.Drawing.cs
+++ b/netstandard/ref/System.Drawing.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/netstandard/ref/System.IO.Compression.FileSystem.cs
+++ b/netstandard/ref/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/netstandard/ref/System.IO.Compression.cs
+++ b/netstandard/ref/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/netstandard/ref/System.Net.Http.cs
+++ b/netstandard/ref/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/netstandard/ref/System.Numerics.cs
+++ b/netstandard/ref/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/netstandard/ref/System.Runtime.Serialization.cs
+++ b/netstandard/ref/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/netstandard/ref/System.Web.cs
+++ b/netstandard/ref/System.Web.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/netstandard/ref/System.Xml.Linq.cs
+++ b/netstandard/ref/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/netstandard/ref/System.Xml.cs
+++ b/netstandard/ref/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/netstandard/ref/System.cs
+++ b/netstandard/ref/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/netstandard/ref/license-header.txt
+++ b/netstandard/ref/license-header.txt
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+

--- a/netstandard/ref/mscorlib.appdomain.cs
+++ b/netstandard/ref/mscorlib.appdomain.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 
 namespace System
 {

--- a/netstandard/ref/mscorlib.cs
+++ b/netstandard/ref/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public abstract partial class CriticalHandleMinusOneIsInvalid : System.Runtime.InteropServices.CriticalHandle

--- a/platforms/net461/System.ComponentModel.Composition.cs
+++ b/platforms/net461/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/net461/System.Core.cs
+++ b/platforms/net461/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/net461/System.Data.cs
+++ b/platforms/net461/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/net461/System.Drawing.cs
+++ b/platforms/net461/System.Drawing.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     public sealed partial class Bitmap : System.Drawing.Image

--- a/platforms/net461/System.IO.Compression.FileSystem.cs
+++ b/platforms/net461/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/net461/System.IO.Compression.cs
+++ b/platforms/net461/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/net461/System.Net.Http.cs
+++ b/platforms/net461/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/net461/System.Numerics.cs
+++ b/platforms/net461/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/net461/System.Runtime.Serialization.cs
+++ b/platforms/net461/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/net461/System.Web.cs
+++ b/platforms/net461/System.Web.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/net461/System.Xml.Linq.cs
+++ b/platforms/net461/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/net461/System.Xml.cs
+++ b/platforms/net461/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/net461/System.cs
+++ b/platforms/net461/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.CSharp
 {
     public partial class CSharpCodeProvider : System.CodeDom.Compiler.CodeDomProvider

--- a/platforms/net461/mscorlib.cs
+++ b/platforms/net461/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/net461/seed.cmd
+++ b/platforms/net461/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\.NET Framework 4.6.1
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Data.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt

--- a/platforms/xamarin.android/Mono.Android.cs
+++ b/platforms/xamarin.android/Mono.Android.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.android/System.ComponentModel.Composition.cs
+++ b/platforms/xamarin.android/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/xamarin.android/System.Core.cs
+++ b/platforms/xamarin.android/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.android/System.Data.cs
+++ b/platforms/xamarin.android/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/xamarin.android/System.IO.Compression.FileSystem.cs
+++ b/platforms/xamarin.android/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/xamarin.android/System.IO.Compression.cs
+++ b/platforms/xamarin.android/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/xamarin.android/System.Net.Http.cs
+++ b/platforms/xamarin.android/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/xamarin.android/System.Numerics.cs
+++ b/platforms/xamarin.android/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.android/System.Runtime.Serialization.cs
+++ b/platforms/xamarin.android/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/xamarin.android/System.Web.Services.cs
+++ b/platforms/xamarin.android/System.Web.Services.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/xamarin.android/System.Xml.Linq.cs
+++ b/platforms/xamarin.android/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/xamarin.android/System.Xml.cs
+++ b/platforms/xamarin.android/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/xamarin.android/System.cs
+++ b/platforms/xamarin.android/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.android/mscorlib.cs
+++ b/platforms/xamarin.android/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/xamarin.android/seed.cmd
+++ b/platforms/xamarin.android/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\Xamarin.iOS 4.2.0.584
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Web.Services.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt

--- a/platforms/xamarin.ios/OpenTK-1.0.cs
+++ b/platforms/xamarin.ios/OpenTK-1.0.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.ios/System.ComponentModel.Composition.cs
+++ b/platforms/xamarin.ios/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/xamarin.ios/System.Core.cs
+++ b/platforms/xamarin.ios/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.ios/System.Data.cs
+++ b/platforms/xamarin.ios/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/xamarin.ios/System.IO.Compression.FileSystem.cs
+++ b/platforms/xamarin.ios/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/xamarin.ios/System.IO.Compression.cs
+++ b/platforms/xamarin.ios/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/xamarin.ios/System.Net.Http.cs
+++ b/platforms/xamarin.ios/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/xamarin.ios/System.Numerics.cs
+++ b/platforms/xamarin.ios/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.ios/System.Runtime.Serialization.cs
+++ b/platforms/xamarin.ios/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/xamarin.ios/System.Web.Services.cs
+++ b/platforms/xamarin.ios/System.Web.Services.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/xamarin.ios/System.Xml.Linq.cs
+++ b/platforms/xamarin.ios/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/xamarin.ios/System.Xml.cs
+++ b/platforms/xamarin.ios/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/xamarin.ios/System.cs
+++ b/platforms/xamarin.ios/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.ios/Xamarin.iOS.cs
+++ b/platforms/xamarin.ios/Xamarin.iOS.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.ios/mscorlib.cs
+++ b/platforms/xamarin.ios/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/xamarin.ios/seed.cmd
+++ b/platforms/xamarin.ios/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\Xamarin.iOS 4.2.0.584
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Data.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt

--- a/platforms/xamarin.mac/OpenTK.cs
+++ b/platforms/xamarin.mac/OpenTK.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.mac/System.ComponentModel.Composition.cs
+++ b/platforms/xamarin.mac/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/xamarin.mac/System.Core.cs
+++ b/platforms/xamarin.mac/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.mac/System.Data.cs
+++ b/platforms/xamarin.mac/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/xamarin.mac/System.IO.Compression.FileSystem.cs
+++ b/platforms/xamarin.mac/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/xamarin.mac/System.IO.Compression.cs
+++ b/platforms/xamarin.mac/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/xamarin.mac/System.Net.Http.cs
+++ b/platforms/xamarin.mac/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/xamarin.mac/System.Numerics.cs
+++ b/platforms/xamarin.mac/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.mac/System.Runtime.Serialization.cs
+++ b/platforms/xamarin.mac/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/xamarin.mac/System.Web.Services.cs
+++ b/platforms/xamarin.mac/System.Web.Services.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/xamarin.mac/System.Xml.Linq.cs
+++ b/platforms/xamarin.mac/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/xamarin.mac/System.Xml.cs
+++ b/platforms/xamarin.mac/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/xamarin.mac/System.cs
+++ b/platforms/xamarin.mac/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.mac/Xamarin.Mac.cs
+++ b/platforms/xamarin.mac/Xamarin.Mac.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.mac/mscorlib.cs
+++ b/platforms/xamarin.mac/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/xamarin.mac/seed.cmd
+++ b/platforms/xamarin.mac/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\Xamarin.iOS 4.2.0.584
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Web.Services.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt

--- a/platforms/xamarin.tvos/OpenTK-1.0.cs
+++ b/platforms/xamarin.tvos/OpenTK-1.0.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.tvos/System.ComponentModel.Composition.cs
+++ b/platforms/xamarin.tvos/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/xamarin.tvos/System.Core.cs
+++ b/platforms/xamarin.tvos/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.tvos/System.Data.cs
+++ b/platforms/xamarin.tvos/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/xamarin.tvos/System.IO.Compression.FileSystem.cs
+++ b/platforms/xamarin.tvos/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/xamarin.tvos/System.IO.Compression.cs
+++ b/platforms/xamarin.tvos/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/xamarin.tvos/System.Net.Http.cs
+++ b/platforms/xamarin.tvos/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/xamarin.tvos/System.Numerics.cs
+++ b/platforms/xamarin.tvos/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.tvos/System.Runtime.Serialization.cs
+++ b/platforms/xamarin.tvos/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/xamarin.tvos/System.Web.Services.cs
+++ b/platforms/xamarin.tvos/System.Web.Services.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/xamarin.tvos/System.Xml.Linq.cs
+++ b/platforms/xamarin.tvos/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/xamarin.tvos/System.Xml.cs
+++ b/platforms/xamarin.tvos/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/xamarin.tvos/System.cs
+++ b/platforms/xamarin.tvos/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.tvos/Xamarin.TVOS.cs
+++ b/platforms/xamarin.tvos/Xamarin.TVOS.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.tvos/mscorlib.cs
+++ b/platforms/xamarin.tvos/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/xamarin.tvos/seed.cmd
+++ b/platforms/xamarin.tvos/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\Xamarin.iOS 4.2.0.584
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Web.Services.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt

--- a/platforms/xamarin.watchos/System.ComponentModel.Composition.cs
+++ b/platforms/xamarin.watchos/System.ComponentModel.Composition.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Lazy<T, TMetadata> : System.Lazy<T>

--- a/platforms/xamarin.watchos/System.Core.cs
+++ b/platforms/xamarin.watchos/System.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.watchos/System.Data.cs
+++ b/platforms/xamarin.watchos/System.Data.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.SqlServer.Server
 {
     public enum DataAccessKind

--- a/platforms/xamarin.watchos/System.IO.Compression.FileSystem.cs
+++ b/platforms/xamarin.watchos/System.IO.Compression.FileSystem.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public static partial class ZipFile

--- a/platforms/xamarin.watchos/System.IO.Compression.cs
+++ b/platforms/xamarin.watchos/System.IO.Compression.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.IO.Compression
 {
     public partial class ZipArchive : System.IDisposable

--- a/platforms/xamarin.watchos/System.Net.Http.cs
+++ b/platforms/xamarin.watchos/System.Net.Http.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Net.Http
 {
     public partial class ByteArrayContent : System.Net.Http.HttpContent

--- a/platforms/xamarin.watchos/System.Numerics.cs
+++ b/platforms/xamarin.watchos/System.Numerics.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.watchos/System.Runtime.Serialization.cs
+++ b/platforms/xamarin.watchos/System.Runtime.Serialization.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Runtime.Serialization
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false, AllowMultiple=false)]

--- a/platforms/xamarin.watchos/System.Web.Services.cs
+++ b/platforms/xamarin.watchos/System.Web.Services.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Web
 {
     public sealed partial class HttpUtility

--- a/platforms/xamarin.watchos/System.Xml.Linq.cs
+++ b/platforms/xamarin.watchos/System.Xml.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml.Linq
 {
     public static partial class Extensions

--- a/platforms/xamarin.watchos/System.Xml.cs
+++ b/platforms/xamarin.watchos/System.Xml.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Xml
 {
     public enum ConformanceLevel

--- a/platforms/xamarin.watchos/System.cs
+++ b/platforms/xamarin.watchos/System.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid

--- a/platforms/xamarin.watchos/Xamarin.WatchOS.cs
+++ b/platforms/xamarin.watchos/Xamarin.WatchOS.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Drawing
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/platforms/xamarin.watchos/mscorlib.cs
+++ b/platforms/xamarin.watchos/mscorlib.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Win32
 {
     public static partial class Registry

--- a/platforms/xamarin.watchos/seed.cmd
+++ b/platforms/xamarin.watchos/seed.cmd
@@ -4,4 +4,4 @@ pushd \\fxcore\Platforms\ApiCatalog\Xamarin.iOS 4.2.0.584
 ::"mscorlib.dll;System.dll;System.Core.dll;System.Drawing.dll;System.IO.Compression.dll;System.IO.Compression.FileSystem.dll;System.Net.Http.dll;System.Numerics.dll;System.Runtime.Serialization.dll;System.Xml.dll;System.Xml.Linq.dll;System.Web.dll"
 set SeedAssemblies="System.Web.Services.dll"
 
-\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt
+\\fxcore\tools\others\GenApi\genapi.exe -assembly %SeedAssemblies% -libPath . -out %~dp0 -excludeAttributesList %~dp0..\attributeExcludeList.txt -headerFile %~dp0..\..\netstandard\ref\license-header.txt


### PR DESCRIPTION
For files that are generated via genapi.exe there's now a license-header.txt that can be prepended to the generated source.

Fixes #103

/cc @weshaggard 