### PR TITLE
Add Conflict Resolution task

### DIFF
--- a/dir.proj
+++ b/dir.proj
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="netstandard/ref/*.csproj" />
     <Project Include="netstandard/src/*.builds" />
+    <Project Include="netstandard/tools/*.builds" />
     <Project Include="extensions/dir.proj" />
     <Project Include="platforms/dir.proj" />
     <Project Include="compatshims/shims.proj" />

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -33,6 +33,21 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
+  <Target Name="GetFilesToPackage" DependsOnTargets="FilterProjects"
+          Returns="@(FilesToPackage)">
+    <MSBuild Targets="GetFilesToPackage"
+             Projects="@(Project)"
+             BuildInParallel="true"
+             Properties="$(ProjectProperties)"
+             ContinueOnError="ErrorAndContinue" >
+      <Output TaskParameter="TargetOutputs"
+              ItemName="FilesToPackage" />
+    </MSBuild>
+
+    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
+    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
+  </Target>
+
   <Target Name="CleanAllProjects" DependsOnTargets="FilterProjects">
     <PropertyGroup>
       <DefaultCleanAllTarget Condition="'$(DefaultCleanAllTarget)'==''">Clean</DefaultCleanAllTarget>

--- a/netstandard/pkg/NETStandard.Library2.pkgproj
+++ b/netstandard/pkg/NETStandard.Library2.pkgproj
@@ -12,7 +12,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\netstandard.csproj" />
+    <ProjectReference Include="..\tools\NETStandard.tools.builds" />
     <ProjectReference Include="..\..\compatshims\shims.proj" />
+    
+    <File Include="..\tools\NETStandard.Library.targets">
+      <TargetPath>build/$(Id).targets</TargetPath>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -1,0 +1,215 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class HandlePackageFileConflicts : Task
+    {
+        [Required]
+        public ITaskItem[] ResolvedReferences { get; set; }
+
+        [Required]
+        public ITaskItem[] ResolvedCopyLocalItems { get; set; }
+
+        [Output]
+        public ITaskItem[] ConflictingReferences { get; set; }
+        [Output]
+
+        public ITaskItem[] ConflictingCopyLocalItems { get; set; }
+
+
+        public override bool Execute()
+        {
+            var conflictingReferences = new List<ITaskItem>();
+            HandleConflicts(ResolvedReferences, conflictingReferences);
+            ConflictingReferences = conflictingReferences.ToArray();
+
+            var conflictingCopyLocalItems = new List<ITaskItem>();
+            HandleConflicts(ResolvedCopyLocalItems, conflictingCopyLocalItems);
+            ConflictingCopyLocalItems = conflictingCopyLocalItems.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        void HandleConflicts(ITaskItem[] items, ICollection<ITaskItem> conflicts)
+        {
+            var targetPathToItem = new Dictionary<string, ITaskItem>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in items)
+            {
+                var targetPath = GetTargetPath(item);
+
+                ITaskItem existingItem;
+
+                if (targetPathToItem.TryGetValue(targetPath, out existingItem))
+                {
+                    // a conflict was found, determine the winner.
+                    var winner = HandleConflict(existingItem, item);
+
+                    if (winner != existingItem)
+                    {
+                        // replace existing item and add it to conflict list.
+                        targetPathToItem[targetPath] = item;
+                        conflicts.Add(existingItem);
+                    }
+                    else
+                    {
+                        // no need to replace item, just add new item to conflict list.
+                        conflicts.Add(item);
+                    }
+                }
+                else
+                {
+                    targetPathToItem[targetPath] = item;
+                }
+            }
+        }
+
+
+        private static string GetSourcePath(ITaskItem item)
+        {
+            var sourcePath = item.GetMetadata("HintPath");
+
+            if (String.IsNullOrWhiteSpace(sourcePath))
+            {
+                sourcePath = item.ItemSpec;
+            }
+
+            return sourcePath;
+        }
+
+        static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "Path" };
+        private static string GetTargetPath(ITaskItem item)
+        {
+            foreach (var metadata in s_targetPathMetadata)
+            {
+                var targetPath = item.GetMetadata("TargetPath");
+
+                if (!String.IsNullOrWhiteSpace(targetPath))
+                {
+                    return targetPath.Replace('\\', '/');
+                }
+            }
+
+            var sourcePath = GetSourcePath(item);
+
+            return Path.GetFileName(sourcePath);
+        }
+
+
+        private ITaskItem HandleConflict(ITaskItem item1, ITaskItem item2)
+        {
+            var conflictMessage = $"Encountered conflict between {item1.ItemSpec} and {item2.ItemSpec}.";
+
+            var sourcePath1 = GetSourcePath(item1);
+            var sourcePath2 = GetSourcePath(item2);
+
+            var exists1 = File.Exists(sourcePath1);
+            var exists2 = File.Exists(sourcePath2);
+
+            if (!exists1 && !exists2)
+            {
+                Log.LogMessage($"{conflictMessage}.  Could not determine winner because {sourcePath1} and {sourcePath2} do not exist.  Arbitrarily choosing {item1.ItemSpec}.");
+                return item1;
+            }
+
+            if (exists1 && !exists2)
+            {
+                Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath1} exists and {sourcePath2} does not.");
+                return item1;
+            }
+
+            if (!exists1 && exists2)
+            {
+                Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath2} exists and {sourcePath1} does not.");
+                return item2;
+            }
+
+            var assemblyVersion1 = GetAssemblyVersion(sourcePath1);
+            var assemblyVersion2 = GetAssemblyVersion(sourcePath2);
+
+            if (assemblyVersion1 != null || assemblyVersion2 != null)
+            {
+                if (assemblyVersion1 == null)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath1} had no AssemblyVersion and {sourcePath2} did.");
+                    return item2;
+                }
+
+                if (assemblyVersion2 == null)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath2} had no AssemblyVersion and {sourcePath1} did.");
+                    return item1;
+                }
+
+                if (assemblyVersion1 > assemblyVersion2)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
+                    return item1;
+                }
+
+                if (assemblyVersion2 > assemblyVersion1)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
+                    return item2;
+                }
+
+                // if (assemblyVersion1 == assemblyVersion2) continue
+            }
+
+            var fileVersion1 = GetFileVersion(sourcePath1);
+            var fileVersion2 = GetFileVersion(sourcePath2);
+
+            if (fileVersion1 != null || fileVersion2 != null)
+            {
+                if (fileVersion1 == null)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath1} had no AssemblyVersion and {sourcePath2} did.");
+                    return item2;
+                }
+
+                if (fileVersion2 == null)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath2} had no AssemblyVersion and {sourcePath1} did.");
+                    return item1;
+                }
+
+                if (fileVersion1 > fileVersion2)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because FileVersion {fileVersion1} is greater than {fileVersion2}.");
+                    return item1;
+                }
+
+                if (fileVersion2 > fileVersion1)
+                {
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because FileVersion {fileVersion2} is greater than {fileVersion1}.");
+                    return item2;
+                }
+
+                // if (fileVersion1 == fileVersion2) continue
+            }
+
+            Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal File and Assembly versions.  Arbitrarily choosing {item1.ItemSpec}.");
+            return item1;
+        }
+
+        private Version GetFileVersion(string sourcePath)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
+        }
+    }
+}

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -148,8 +148,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 return null;
             }
             
-            var assemblyVersion1 = GetAssemblyVersion(sourcePath1);
-            var assemblyVersion2 = GetAssemblyVersion(sourcePath2);
+            var assemblyVersion1 = TryGetAssemblyVersion(sourcePath1);
+            var assemblyVersion2 = TryGetAssemblyVersion(sourcePath2);
 
             // if only one is missing version
             if (assemblyVersion1 == null ^ assemblyVersion2 == null)
@@ -233,6 +233,15 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             return result;
+        }
+
+
+        static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
+        private static Version TryGetAssemblyVersion(string sourcePath)
+        {
+            var extension = Path.GetExtension(sourcePath);
+
+            return s_assemblyExtensions.Contains(extension) ? GetAssemblyVersion(sourcePath) : null;
         }
     }
 }

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -21,10 +21,9 @@ namespace Microsoft.DotNet.Build.Tasks
 
         [Output]
         public ITaskItem[] ConflictingReferences { get; set; }
+
         [Output]
-
         public ITaskItem[] ConflictingCopyLocalItems { get; set; }
-
 
         public override bool Execute()
         {
@@ -53,6 +52,13 @@ namespace Microsoft.DotNet.Build.Tasks
                     // a conflict was found, determine the winner.
                     var winner = HandleConflict(existingItem, item);
 
+                    if (winner == null)
+                    {
+                        // no winner, skip it.
+                        // don't add to conflict list and just use the existing item for future conflicts.
+                        continue;
+                    }
+
                     if (winner != existingItem)
                     {
                         // replace existing item and add it to conflict list.
@@ -72,6 +78,17 @@ namespace Microsoft.DotNet.Build.Tasks
             }
         }
 
+        private Version GetFileVersion(string sourcePath)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
+        }
 
         private static string GetSourcePath(ITaskItem item)
         {
@@ -88,13 +105,14 @@ namespace Microsoft.DotNet.Build.Tasks
         static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "Path" };
         private static string GetTargetPath(ITaskItem item)
         {
+            // first use TargetPath, then Path, then fallback to filename+extension alone
             foreach (var metadata in s_targetPathMetadata)
             {
-                var targetPath = item.GetMetadata("TargetPath");
+                var value = item.GetMetadata(metadata);
 
-                if (!String.IsNullOrWhiteSpace(targetPath))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
-                    return targetPath.Replace('\\', '/');
+                    return value.Replace('\\', '/');
                 }
             }
 
@@ -102,7 +120,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
             return Path.GetFileName(sourcePath);
         }
-
 
         private ITaskItem HandleConflict(ITaskItem item1, ITaskItem item2)
         {
@@ -114,41 +131,31 @@ namespace Microsoft.DotNet.Build.Tasks
             var exists1 = File.Exists(sourcePath1);
             var exists2 = File.Exists(sourcePath2);
 
-            if (!exists1 && !exists2)
+            if (!exists1 || !exists2)
             {
-                Log.LogMessage($"{conflictMessage}.  Could not determine winner because {sourcePath1} and {sourcePath2} do not exist.  Arbitrarily choosing {item1.ItemSpec}.");
-                return item1;
-            }
+                var fileMessage = !exists1 ?
+                                    !exists2 ? 
+                                      "both files do" :
+                                      $"{item1.ItemSpec} does" :
+                                  $"{item2.ItemSpec} does";
 
-            if (exists1 && !exists2)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath1} exists and {sourcePath2} does not.");
-                return item1;
+                Log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
+                return null;
             }
-
-            if (!exists1 && exists2)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath2} exists and {sourcePath1} does not.");
-                return item2;
-            }
-
+            
             var assemblyVersion1 = GetAssemblyVersion(sourcePath1);
             var assemblyVersion2 = GetAssemblyVersion(sourcePath2);
 
-            if (assemblyVersion1 != null || assemblyVersion2 != null)
+            // if only one is missing version
+            if (assemblyVersion1 == null ^ assemblyVersion2 == null)
             {
-                if (assemblyVersion1 == null)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath1} had no AssemblyVersion and {sourcePath2} did.");
-                    return item2;
-                }
+                var nonAssembly = assemblyVersion1 == null ? item1.ItemSpec : item2.ItemSpec;
+                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
+                return null;
+            }
 
-                if (assemblyVersion2 == null)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath2} had no AssemblyVersion and {sourcePath1} did.");
-                    return item1;
-                }
-
+            if (assemblyVersion1 != assemblyVersion2)
+            {
                 if (assemblyVersion1 > assemblyVersion2)
                 {
                     Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
@@ -160,55 +167,35 @@ namespace Microsoft.DotNet.Build.Tasks
                     Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
                     return item2;
                 }
-
-                // if (assemblyVersion1 == assemblyVersion2) continue
             }
 
             var fileVersion1 = GetFileVersion(sourcePath1);
             var fileVersion2 = GetFileVersion(sourcePath2);
 
-            if (fileVersion1 != null || fileVersion2 != null)
+            // if only one is missing version
+            if (fileVersion1 == null ^ fileVersion2 == null)
             {
-                if (fileVersion1 == null)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because {sourcePath1} had no AssemblyVersion and {sourcePath2} did.");
-                    return item2;
-                }
+                var nonVersion = fileVersion1 == null ? item1.ItemSpec : item2.ItemSpec;
+                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
+                return null;
+            }
 
-                if (fileVersion2 == null)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because {sourcePath2} had no AssemblyVersion and {sourcePath1} did.");
-                    return item1;
-                }
-
+            if (fileVersion1 != fileVersion2)
+            {
                 if (fileVersion1 > fileVersion2)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because FileVersion {fileVersion1} is greater than {fileVersion2}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because file version {fileVersion1} is greater than {fileVersion2}.");
                     return item1;
                 }
 
                 if (fileVersion2 > fileVersion1)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because FileVersion {fileVersion2} is greater than {fileVersion1}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because file version {fileVersion2} is greater than {fileVersion1}.");
                     return item2;
                 }
-
-                // if (fileVersion1 == fileVersion2) continue
             }
 
-            Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal File and Assembly versions.  Arbitrarily choosing {item1.ItemSpec}.");
-            return item1;
-        }
-
-        private Version GetFileVersion(string sourcePath)
-        {
-            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
-
-            if (fvi != null)
-            {
-                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
-            }
-
+            Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
             return null;
         }
     }

--- a/netstandard/tools/HandlePackageFileConflicts.net45.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.net45.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class HandlePackageFileConflicts : Task
     {
-        private Version GetAssemblyVersion(string sourcePath)
+        private static Version GetAssemblyVersion(string sourcePath)
         {
             return AssemblyName.GetAssemblyName(sourcePath)?.Version;
         }

--- a/netstandard/tools/HandlePackageFileConflicts.net45.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.net45.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class HandlePackageFileConflicts : Task
+    {
+        private Version GetAssemblyVersion(string sourcePath)
+        {
+            return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+        }
+    }
+}

--- a/netstandard/tools/HandlePackageFileConflicts.netstandard.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.netstandard.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class HandlePackageFileConflicts : Task
+    {
+        private Version GetAssemblyVersion(string sourcePath)
+        {
+            using (var assemblyStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+            {
+                Version result = null;
+                try
+                {
+                    using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader reader = peReader.GetMetadataReader();
+                            if (reader.IsAssembly)
+                            {
+                                result = reader.GetAssemblyDefinition().Version;
+                            }
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    // not a PE
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/netstandard/tools/HandlePackageFileConflicts.netstandard.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.netstandard.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class HandlePackageFileConflicts : Task
     {
-        private Version GetAssemblyVersion(string sourcePath)
+        private static Version GetAssemblyVersion(string sourcePath)
         {
             using (var assemblyStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
             {

--- a/netstandard/tools/NETStandard.Library.targets
+++ b/netstandard/tools/NETStandard.Library.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and '$(EnableResolvePackageDependencies)' == 'true' and Exists('$(ProjectAssetsFile)')">
+    <When Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and Exists('$(ProjectAssetsFile)')">
       <!-- NuGet 4, run after the target that constructs items from deps -->
       <PropertyGroup>
         <HandlePackageFileConflictsAfter>ResolvePackageDependenciesForBuild</HandlePackageFileConflictsAfter>

--- a/netstandard/tools/NETStandard.Library.targets
+++ b/netstandard/tools/NETStandard.Library.targets
@@ -13,7 +13,7 @@
       </PropertyGroup>
     </When>
     <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
-      <!-- NuGet 4, run after the target that constructs items from lock file -->
+      <!-- NuGet 3, run after the target that constructs items from lock file -->
       <PropertyGroup>
         <HandlePackageFileConflictsAfter>ResolveNuGetPackageAssets</HandlePackageFileConflictsAfter>
       </PropertyGroup>
@@ -29,15 +29,21 @@
 
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
   <Target Name="HandlePackageConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
-    <HandlePackageConflicts ResolvedReferences="@(Reference)"
-                            ResolvedCopyLocalItems="@(ReferenceCopyLocalPaths)">
-      <Output TaskParameter="ConflictingReferences" ItemName="_ReferenceToRemove" />
-      <Output TaskParameter="ConflictingCopyLocalItems" ItemName="_ReferenceCopyLocalPathsToRemove" />
+    <HandlePackageConflicts References="@(Reference)"
+                            ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)">
+      <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
     </HandlePackageConflicts>
 
+    <!-- Replace Reference / ReferenceCopyLocalPaths with the filtered lists.
+         We must remove all and include rather than just remove since removal is based
+         only on ItemSpec and duplicate ItemSpecs may exist with different metadata 
+         (eg: HintPath) -->
     <ItemGroup>
-      <Reference Remove="@(_ReferenceToRemove)" />
-      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsToRemove)" />
+      <Reference Remove="@(Reference)" />
+      <Reference Include="@(_ReferencesWithoutConflicts)" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
+      <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsWithoutConflicts)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/netstandard/tools/NETStandard.Library.targets
+++ b/netstandard/tools/NETStandard.Library.targets
@@ -1,0 +1,43 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(NETStandardToolsTaskDirectory)' == ''">
+    <NETStandardToolsTaskDirectory>$(MSBuildThisFileDirectory)</NETStandardToolsTaskDirectory>
+    <NETStandardToolsTaskDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)desktop/</NETStandardToolsTaskDirectory>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and '$(EnableResolvePackageDependencies)' == 'true' and Exists('$(ProjectAssetsFile)')">
+      <!-- NuGet 4, run after the target that constructs items from deps -->
+      <PropertyGroup>
+        <HandlePackageFileConflictsAfter>ResolvePackageDependenciesForBuild</HandlePackageFileConflictsAfter>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
+      <!-- NuGet 4, run after the target that constructs items from lock file -->
+      <PropertyGroup>
+        <HandlePackageFileConflictsAfter>ResolveNuGetPackageAssets</HandlePackageFileConflictsAfter>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <!-- NuGet 2, run before targets that consume references -->
+      <PropertyGroup>
+        <ResolveAssemblyReferencesDependsOn>$(ResolveAssemblyReferencesDependsOn);HandlePackageFileConflicts</ResolveAssemblyReferencesDependsOn>
+        <PrepareResourcesDependsOn>HandlePackageFileConflicts;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
+  <Target Name="HandlePackageConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
+    <HandlePackageConflicts ResolvedReferences="@(Reference)"
+                            ResolvedCopyLocalItems="@(ReferenceCopyLocalPaths)">
+      <Output TaskParameter="ConflictingReferences" ItemName="_ReferenceToRemove" />
+      <Output TaskParameter="ConflictingCopyLocalItems" ItemName="_ReferenceCopyLocalPathsToRemove" />
+    </HandlePackageConflicts>
+
+    <ItemGroup>
+      <Reference Remove="@(_ReferenceToRemove)" />
+      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsToRemove)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/netstandard/tools/NETStandard.Library.targets
+++ b/netstandard/tools/NETStandard.Library.targets
@@ -30,7 +30,8 @@
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
   <Target Name="HandlePackageConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
     <HandlePackageConflicts References="@(Reference)"
-                            ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)">
+                            ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+                            PrefferedPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
     </HandlePackageConflicts>

--- a/netstandard/tools/NETStandard.Tools.builds
+++ b/netstandard/tools/NETStandard.Tools.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj" />
+    <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj">
+      <TargetGroup>net45</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net45'">.NETFramework,Version=v4.5</NuGetTargetMoniker>
+    <CLSCompliant>false</CLSCompliant>
+    <ProjectGuid>{65E58605-AE96-46C2-8C6C-F28A5EB9B565}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
+  <ItemGroup>
+    <Compile Include="HandlePackageFileConflicts.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
+    <Compile Include="HandlePackageFileConflicts.netstandard.cs" />
+    <PackageDestination Include="build" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
+    <Compile Include="HandlePackageFileConflicts.net45.cs" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="Microsoft.Build" />
+    <TargetingPackReference Include="Microsoft.Build.Framework" />
+    <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
+    <PackageDestination Include="build/desktop" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="NETStandard.Library.targets" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/netstandard/tools/project.json
+++ b/netstandard/tools/project.json
@@ -1,0 +1,28 @@
+﻿{
+  "dependencies": {
+    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
+    "NETStandard.Library": "1.6.0",
+    "System.Reflection.Metadata": "1.3.0"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "dependencies": {
+        "Microsoft.Build": "0.1.0-preview-00022",
+        "Microsoft.Build.Framework": "0.1.0-preview-00022",
+        "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
+        "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+        "Microsoft.Tpl.Dataflow": {
+          "version": "4.5.24",
+          "exclude": "all"
+        },
+        "System.Diagnostics.FileVersionInfo": "4.0.0"
+      },
+      "imports": [ "dnxcore50", "portable-net45+win8+wpa81" ]
+    },
+    "net45": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a task that runs after NuGet has resolved packages to identify
file conflicts in references and copy-local assets and choose a winner.

/cc @terrajobst @weshaggard 