### PR TITLE
Clarify HandlePackageFileConflicts

### DIFF
--- a/netstandard/tools/NETStandard.Library.targets
+++ b/netstandard/tools/NETStandard.Library.targets
@@ -31,7 +31,7 @@
   <Target Name="HandlePackageConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
     <HandlePackageConflicts References="@(Reference)"
                             ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                            PrefferedPackages="$(PackageConflictPreferredPackages)">
+                            PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
     </HandlePackageConflicts>

--- a/netstandard/tools/NETStandard.Tools.builds
+++ b/netstandard/tools/NETStandard.Tools.builds
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- restore happens during build and these projects share a 
+         lock file, don't build them in parallel -->
+    <SerializeProjects>true</SerializeProjects>
+  </PropertyGroup>
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj" />
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj">

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
     <Compile Include="HandlePackageFileConflicts.cs" />
+    <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
     <Compile Include="HandlePackageFileConflicts.netstandard.cs" />

--- a/netstandard/tools/ReferenceComparer.cs
+++ b/netstandard/tools/ReferenceComparer.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal class ReferenceComparer<T> : IEqualityComparer, IEqualityComparer<T>
+    {
+        public static ReferenceComparer<T> Instance { get; } = new ReferenceComparer<T>();
+
+        public bool Equals(T x, T y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+
+        public int GetHashCode(object obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}


### PR DESCRIPTION
Fix a few typos, rename members for readability, add comments.

Ensure we use reference-equality for the conflict hashset.  We're
specifically trying to remove duplicate instances and don't want
any other comparer getting in the way of what is perceived as a
duplicate.

/cc @weshaggard @danmosemsft 