### PR TITLE
Better conflict resolution for references

### DIFF
--- a/netstandard/tools/MSBuildUtilities.cs
+++ b/netstandard/tools/MSBuildUtilities.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Internal utilties copied from microsoft/MSBuild repo.
+    /// </summary>
+    class MSBuildUtilities
+    {
+        /// <summary>
+        /// Converts a string to a bool.  We consider "true/false", "on/off", and 
+        /// "yes/no" to be valid boolean representations in the XML.
+        /// Modified from its original version to not throw, but return a default value.
+        /// </summary>
+        /// <param name="parameterValue">The string to convert.</param>
+        /// <returns>Boolean true or false, corresponding to the string.</returns>
+        internal static bool ConvertStringToBool(string parameterValue, bool defaultValue = false)
+        {
+            if (String.IsNullOrEmpty(parameterValue))
+            {
+                return defaultValue;
+            }
+            else if (ValidBooleanTrue(parameterValue))
+            {
+                return true;
+            }
+            else if (ValidBooleanFalse(parameterValue))
+            {
+                return false;
+            }
+            else
+            {
+                // Unsupported boolean representation.
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean true value,
+        /// such as "on", "!false", "yes"
+        /// </summary>
+        private static bool ValidBooleanTrue(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean false value,
+        /// such as "!on" "off" "no" "!true"
+        /// </summary>
+        private static bool ValidBooleanFalse(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+    }
+}

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
     <Compile Include="HandlePackageFileConflicts.cs" />
+    <Compile Include="MSBuildUtilities.cs" />
     <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net45'">


### PR DESCRIPTION
Determine reference conflict by assembly name rather than target path.

Identify Private references and check for conflicts with copy-local items.

/cc @weshaggard @terrajobst @danmosemsft 