### PR TITLE
Add NETStandard assets only for NETStandard projects

### DIFF
--- a/compatshims/shims.proj
+++ b/compatshims/shims.proj
@@ -8,15 +8,15 @@
     <NetstandardRefPath>$(BinDir)ref/netstandard/2.0.0.0/</NetstandardRefPath>
     <ProjectJson>$(MSBuildThisFileDirectory)project.json</ProjectJson>
     <ProjectLockJson>$(MSBuildThisFileDirectory)project.lock.json</ProjectLockJson>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <Target Name="FacadesToPackage"
           AfterTargets="RunGenFacades">
     <ItemGroup>
-      <!-- Temporarily target ns17 until we get ns20 mapping https://github.com/NuGet/Home/issues/3576 -->
       <FilesToPackage Include="$(GenFacadesOutputPath)\*.dll">
-        <TargetFramework>.NETStandard,Version=v1.7</TargetFramework>
-        <TargetPath>ref/netstandard1.7</TargetPath>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+        <TargetPath>build/$(TargetFramework)/ref</TargetPath>
         <IsReferenceAsset>true</IsReferenceAsset>
       </FilesToPackage>
     </ItemGroup>

--- a/netstandard/pkg/NETStandard.Library2.pkgproj
+++ b/netstandard/pkg/NETStandard.Library2.pkgproj
@@ -8,17 +8,38 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <OmitDependencies>true</OmitDependencies>
     <SkipValidatePackage>true</SkipValidatePackage>
+    <TargetsFileName>NETStandard.Library.targets</TargetsFileName>
+    <RootTargetsTemplate>..\tools\targets\$(TargetsFileName)</RootTargetsTemplate>
+    <RootTargetsSource>$(IntermediateOutputPath)$(TargetsFileName)</RootTargetsSource>
+    <NETStandardVersion>netstandard2.0</NETStandardVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ref\netstandard.csproj" />
     <ProjectReference Include="..\tools\NETStandard.tools.builds" />
     <ProjectReference Include="..\..\compatshims\shims.proj" />
-    
-    <File Include="..\tools\NETStandard.Library.targets">
+
+    <File Include="$(RootTargetsSource)">
       <TargetPath>build/$(Id).targets</TargetPath>
     </File>
+
+    <File Include="..\tools\targets\netstandard\$(TargetsFileName)">
+      <TargetPath>build/$(NETStandardVersion)/$(Id).targets</TargetPath>
+    </File>
+
+    <!-- Temporarily map ns17 to the ns20 refs https://github.com/NuGet/Home/issues/3576 -->
+    <File Include="..\tools\targets\netstandard1.7\$(TargetsFileName)">
+      <TargetPath>build/netstandard1.7/$(Id).targets</TargetPath>
+    </File>
   </ItemGroup>
+  
+  <Target Name="StampPackageVersionInTargets" BeforeTargets="GenerateNuSpec">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
+    <WriteLinesToFile File="$(RootTargetsSource)"
+                      Lines="$([System.IO.File]::ReadAllText('$(RootTargetsTemplate)').Replace('#VERSION#', '$(PackageVersion)'))"
+                      Overwrite="true" />
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/netstandard/ref/netstandard.csproj
+++ b/netstandard/ref/netstandard.csproj
@@ -5,8 +5,7 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <!-- Temporarily target ns17 until we get ns20 mapping https://github.com/NuGet/Home/issues/3576 -->
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsCoreAssembly>true</IsCoreAssembly>
     <!-- disable obsolete warnings/errors -->
     <NoWarn>$(NoWarn);0618;0619;0809</NoWarn>  
@@ -14,6 +13,11 @@
     <DefaultBuildAllTarget>Build</DefaultBuildAllTarget>
     <BuildAllProjects>true</BuildAllProjects>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageDestination Include="build/$(TargetFramework)/ref">
+      <TargetFramework>$(TargetFramework)</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="mscorlib.cs" />
     <Compile Include="mscorlib.appdomain.cs" />

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -15,10 +15,8 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         private Dictionary<string, int> packageRanks = null;
 
-        [Required]
         public ITaskItem[] References { get; set; }
-
-        [Required]
+        
         public ITaskItem[] ReferenceCopyLocalPaths { get; set; }
 
         /// <summary>
@@ -99,6 +97,12 @@ namespace Microsoft.DotNet.Build.Tasks
         private ITaskItem[] HandleConflicts(ITaskItem[] items, Func<ITaskItem, string> getItemKey, out Dictionary<string, ITaskItem> winningItemsByKey)
         {
             winningItemsByKey = new Dictionary<string, ITaskItem>(StringComparer.OrdinalIgnoreCase);
+
+            if (items == null)
+            {
+                return items;
+            }
+
             // ensure we use reference equality and not any overridden equality operators on items
             var conflictsToRemove = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
 
@@ -318,10 +322,10 @@ namespace Microsoft.DotNet.Build.Tasks
             return sourcePath;
         }
 
-        static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "Path" };
+        static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "DestinationSubPath", "Path" };
         private static string GetTargetPath(ITaskItem item)
         {
-            // first use TargetPath, then Path, then fallback to filename+extension alone
+            // first use TargetPath, DestinationSubPath, then Path, then fallback to filename+extension alone
             foreach (var metadata in s_targetPathMetadata)
             {
                 var value = item.GetMetadata(metadata);

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -29,7 +29,9 @@
     <PackageDestination Include="build/desktop" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="NETStandard.Library.targets" />
+    <None Include="targets\netstandard1.7\NETStandard.Library.targets" />
+    <None Include="targets\netstandard\NETStandard.Library.targets" />
+    <None Include="targets\NETStandard.Library.targets" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -5,6 +5,10 @@
     <NETStandardToolsTaskDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)desktop/</NETStandardToolsTaskDirectory>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NETStandardLibraryPackageVersion>#VERSION#</NETStandardLibraryPackageVersion>
+  </PropertyGroup>
+
   <Choose>
     <When Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and Exists('$(ProjectAssetsFile)')">
       <!-- NuGet 4, run after the target that constructs items from deps -->
@@ -26,6 +30,24 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <ItemGroup>
+    <Reference Condition="'$(_NetStandardLibraryRefPath)' != ''" Include="$(_NetStandardLibraryRefPath)*.dll">
+      <!-- Private = false to make these reference only -->
+      <Private>false</Private>
+      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
+      <NuGetSourceType>Package</NuGetSourceType>
+    </Reference>
+    <ReferenceCopyLocalPaths Condition="'$(_NetStandardLibraryLibPath)' != ''" Include="$(_NetStandardLibraryLibPath)*.dll">
+      <Private>false</Private>
+      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
+      <NuGetSourceType>Package</NuGetSourceType>
+    </ReferenceCopyLocalPaths>
+  </ItemGroup>
 
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
   <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -10,10 +10,12 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and Exists('$(ProjectAssetsFile)')">
-      <!-- NuGet 4, run after the target that constructs items from deps -->
+    <!-- Condition here is a hack until https://github.com/dotnet/sdk/issues/534 is fixed -->
+    <When Condition="'$(TargetFramework)' != '' or '$(TargetFrameworks)' != ''">
+      <!-- NuGet 4, run after the targets that construct items from deps -->
       <PropertyGroup>
         <HandlePackageFileConflictsAfter>ResolvePackageDependenciesForBuild</HandlePackageFileConflictsAfter>
+        <HandlePublishFileConflictsAfter>RunResolvePublishAssemblies</HandlePublishFileConflictsAfter>
       </PropertyGroup>
     </When>
     <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
@@ -52,8 +54,8 @@
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
   <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
     <HandlePackageFileConflicts References="@(Reference)"
-                            ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                            PreferredPackages="$(PackageConflictPreferredPackages)">
+                                ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+                                PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
     </HandlePackageFileConflicts>
@@ -67,6 +69,17 @@
       <Reference Include="@(_ReferencesWithoutConflicts)" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsWithoutConflicts)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="HandlePublishFileConflicts" AfterTargets="$(HandlePublishFileConflictsAfter)">
+    <HandlePackageFileConflicts ReferenceCopyLocalPaths="@(ResolvedAssembliesToPublish)"
+                                PreferredPackages="$(PackageConflictPreferredPackages)">
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ResolvedAssembliesToPublishWithoutConflicts" />
+    </HandlePackageFileConflicts>
+    <ItemGroup>
+      <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
+      <ResolvedAssembliesToPublish Include="@(_ResolvedAssembliesToPublishWithoutConflicts)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/netstandard/tools/targets/netstandard/NETStandard.Library.targets
+++ b/netstandard/tools/targets/netstandard/NETStandard.Library.targets
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Only add references if we're actually targeting .NETStandard.
+       If the project is targeting some other TFM that is compatible with NETStandard we expect
+       that framework to provide all references for NETStandard, mscorlib, System.* in their own
+       targeting pack / SDK. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <_NetStandardLibraryRefPath>$(MSBuildThisFileDirectory)\ref\</_NetStandardLibraryRefPath>
+  </PropertyGroup>
+
+  <!-- import the TFM-agnostic targets -->
+  <Import Project="..\$(MSBuildThisFile)"/>
+</Project>

--- a/netstandard/tools/targets/netstandard1.7/NETStandard.Library.targets
+++ b/netstandard/tools/targets/netstandard1.7/NETStandard.Library.targets
@@ -4,7 +4,7 @@
        that framework to provide all references for NETStandard, mscorlib, System.* in their own
        targeting pack / SDK. -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <!-- temporarily workaround -->
+    <!-- Temporarily target ns17 until we get ns20 mapping https://github.com/NuGet/Home/issues/3576 -->
     <_NetStandardLibraryRefPath>$(MSBuildThisFileDirectory)..\netstandard2.0\ref\</_NetStandardLibraryRefPath>
   </PropertyGroup>
 

--- a/netstandard/tools/targets/netstandard1.7/NETStandard.Library.targets
+++ b/netstandard/tools/targets/netstandard1.7/NETStandard.Library.targets
@@ -1,0 +1,13 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Only add references if we're actually targeting .NETStandard.
+       If the project is targeting some other TFM that is compatible with NETStandard we expect
+       that framework to provide all references for NETStandard, mscorlib, System.* in their own
+       targeting pack / SDK. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <!-- temporarily workaround -->
+    <_NetStandardLibraryRefPath>$(MSBuildThisFileDirectory)..\netstandard2.0\ref\</_NetStandardLibraryRefPath>
+  </PropertyGroup>
+
+  <!-- import the TFM-agnostic targets -->
+  <Import Project="..\$(MSBuildThisFile)"/>
+</Project>


### PR DESCRIPTION
We don't want to add assets for non-NETStandard projects.

Those assets come from the framework:
- NuGet packages / shared frameworkk for .NETCore & UWP
- Targeting pack for Xamarin
- Targeting pack for some future version of desktop
- For NET4.6.1 -> .NET 4.7 we'll be bundling those shims in this package
   in a future commit.  We need to build versions specific for desktop.

/cc @weshaggard @terrajobst 

With this I am able to use NETCore.App + NETStandard.Library+JSON.Net and restore/build successfully.

Still working through some issues with run and publish.