### PR TITLE
Add previous dependencies to NETStandard.Library

### DIFF
--- a/netstandard/pkg/NETStandard.Library.dependencies.props
+++ b/netstandard/pkg/NETStandard.Library.dependencies.props
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NETStandard10Dependency Include="Microsoft.NETCore.Platforms">
+      <Version>1.1.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Collections">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Diagnostics.Debug">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Diagnostics.Tools">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Globalization">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.IO">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Linq">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Linq.Expressions">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Net.Primitives">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.ObjectModel">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Reflection">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Reflection.Extensions">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Reflection.Primitives">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Resources.ResourceManager">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Runtime">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Runtime.Extensions">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Text.Encoding">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Text.Encoding.Extensions">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Text.RegularExpressions">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Threading">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Threading.Tasks">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Xml.ReaderWriter">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+    <NETStandard10Dependency Include="System.Xml.XDocument">
+      <Version>4.3.0</Version>
+    </NETStandard10Dependency>
+
+    <NETStandard11Dependency Include="System.Collections.Concurrent">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.Diagnostics.Tracing">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.IO.Compression">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.Net.Http">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.Runtime.InteropServices">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+    <NETStandard11Dependency Include="System.Runtime.Numerics">
+      <Version>4.3.0</Version>
+    </NETStandard11Dependency>
+
+    <NETStandard12Dependency Include="System.Threading.Timer">
+      <Version>4.3.0</Version>
+    </NETStandard12Dependency>
+
+    <NETStandard13Dependency Include="Microsoft.Win32.Primitives">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.AppContext">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Console">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Globalization.Calendars">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.IO.Compression.ZipFile">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.IO.FileSystem">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.IO.FileSystem.Primitives">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Net.Sockets">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Runtime.Handles">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Security.Cryptography.Algorithms">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Security.Cryptography.Encoding">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Security.Cryptography.Primitives">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+    <NETStandard13Dependency Include="System.Security.Cryptography.X509Certificates">
+      <Version>4.3.0</Version>
+    </NETStandard13Dependency>
+
+    <Dependency Include="@(NETStandard10Dependency)">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </Dependency>
+    <Dependency Include="@(NETStandard10Dependency);@(NETStandard11Dependency)">
+      <TargetFramework>netstandard1.1</TargetFramework>
+    </Dependency>
+    <Dependency Include="@(NETStandard10Dependency);@(NETStandard11Dependency);@(NETStandard12Dependency)">
+      <TargetFramework>netstandard1.2</TargetFramework>
+    </Dependency>
+    <Dependency Include="@(NETStandard10Dependency);@(NETStandard11Dependency);@(NETStandard12Dependency);@(NETStandard13Dependency)">
+      <TargetFramework>netstandard1.3</TargetFramework>
+    </Dependency>
+  </ItemGroup>
+</Project>

--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -14,6 +14,8 @@
     <NETStandardVersion>netstandard2.0</NETStandardVersion>
   </PropertyGroup>
 
+  <Import Project="NETStandard.Library.dependencies.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\ref\netstandard.csproj" />
     <ProjectReference Include="..\tools\NETStandard.tools.builds" />
@@ -31,6 +33,10 @@
     <File Include="..\tools\targets\netstandard1.7\$(TargetsFileName)">
       <TargetPath>build/netstandard1.7/$(Id).targets</TargetPath>
     </File>
+
+    <Dependency Include="_._">
+      <TargetFramework>netstandard1.7</TargetFramework>
+    </Dependency>
   </ItemGroup>
   
   <Target Name="StampPackageVersionInTargets" BeforeTargets="GenerateNuSpec">

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -5,7 +5,7 @@
         "CommonTypes": [ ]
     },
     {
-        "Name": "NETStandard.Library2",
+        "Name": "NETStandard.Library",
         "Description": "A set of standard .NET APIs that are prescribed to be used and supported together.",
         "CommonTypes": [
         ]


### PR DESCRIPTION
Add dependencies that match NETStandard.Library 1.6.1.

We're now backwards compatible with the previously shipped
NETStandard.Library so I've changed the name back to NETStandard.Library


/cc @weshaggard 