### PR TITLE
Support external conflicts

### DIFF
--- a/netstandard/tools/ConflictItem.cs
+++ b/netstandard/tools/ConflictItem.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal enum ConflictItemType
+    {
+        Reference,
+        CopyLocal,
+        External
+    }
+
+    // Wraps an ITask item and adds lazy evaluated properties used by Conflict resolution.
+    internal class ConflictItem
+    {
+        public ConflictItem(ITaskItem originalItem, ConflictItemType itemType)
+        {
+            OriginalItem = originalItem;
+            ItemType = itemType;
+        }
+
+        private bool hasAssemblyVersion;
+        private Version assemblyVersion;
+        public Version AssemblyVersion
+        {
+            get
+            {
+                if (!hasAssemblyVersion)
+                {
+                    if (ItemType == ConflictItemType.External)
+                    {
+                        assemblyVersion = null;
+
+                        var assemblyVersionString = OriginalItem.GetMetadata(nameof(AssemblyVersion));
+
+                        if (assemblyVersionString.Length != 0)
+                        {
+                            Version.TryParse(assemblyVersionString, out assemblyVersion);
+                        }
+                    }
+                    else
+                    {
+                        assemblyVersion = FileUtilities.TryGetAssemblyVersion(SourcePath);
+                    }
+
+                    // assemblyVersion may be null but don't try to recalculate it
+                    hasAssemblyVersion = true;
+                }
+
+                return assemblyVersion;
+            }
+        }
+
+        public ConflictItemType ItemType { get; }
+
+        private bool? exists;
+        public bool Exists
+        {
+            get
+            {
+                if (exists == null)
+                {
+                    exists = ItemType == ConflictItemType.External || File.Exists(SourcePath);
+                }
+
+                return exists.Value;
+            }
+        }
+
+        private string fileName;
+        public string FileName
+        {
+            get
+            {
+                if (fileName == null)
+                {
+                    fileName = OriginalItem.GetMetadata("FileName") + OriginalItem.GetMetadata("Extension");
+                }
+                return fileName;
+            }
+        }
+
+        private bool hasFileVersion;
+        private Version fileVersion;
+        public Version FileVersion
+        {
+            get
+            {
+                if (!hasFileVersion)
+                {
+                    if (ItemType == ConflictItemType.External)
+                    {
+                        fileVersion = null;
+
+                        var fileVersionString = OriginalItem.GetMetadata(nameof(FileVersion));
+
+                        if (fileVersionString.Length != 0)
+                        {
+                            Version.TryParse(fileVersionString, out fileVersion);
+                        }
+                    }
+                    else
+                    {
+                        fileVersion = FileUtilities.GetFileVersion(SourcePath);
+                    }
+
+                    // fileVersion may be null but don't try to recalculate it
+                    hasFileVersion = true;
+                }
+
+                return fileVersion;
+            }
+        }
+
+        public ITaskItem OriginalItem { get; }
+
+        private string packageId;
+        public string PackageId
+        {
+            get
+            {
+                if (packageId == null)
+                {
+                    packageId = OriginalItem.GetMetadata("NuGetPackageId") ?? String.Empty;
+                }
+
+                return packageId.Length == 0 ? null : packageId;
+            }
+        }
+        
+
+        private string sourcePath;
+        public string SourcePath
+        {
+            get
+            {
+                if (sourcePath == null)
+                {
+                    sourcePath = ItemUtilities.GetSourcePath(OriginalItem) ?? String.Empty;
+                }
+
+                return sourcePath.Length == 0 ? null : sourcePath;
+            }
+        }
+        
+        public string displayName;
+        public string DisplayName
+        {
+            get
+            {
+                if (displayName == null)
+                {
+                    displayName = $"{ItemType}:{OriginalItem.ItemSpec}";
+                }
+                return displayName;
+            }
+        }
+    }
+}

--- a/netstandard/tools/FileUtilities.cs
+++ b/netstandard/tools/FileUtilities.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        public static Version GetFileVersion(string sourcePath)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
+        }
+
+        static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
+        public static Version TryGetAssemblyVersion(string sourcePath)
+        {
+            var extension = Path.GetExtension(sourcePath);
+
+            return s_assemblyExtensions.Contains(extension) ? GetAssemblyVersion(sourcePath) : null;
+        }
+
+    }
+}

--- a/netstandard/tools/FileUtilities.net45.cs
+++ b/netstandard/tools/FileUtilities.net45.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Build.Utilities;
 using System;
 using System.Reflection;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public partial class HandlePackageFileConflicts : Task
+    static partial class FileUtilities
     {
         private static Version GetAssemblyVersion(string sourcePath)
         {

--- a/netstandard/tools/FileUtilities.net45.cs
+++ b/netstandard/tools/FileUtilities.net45.cs
@@ -11,7 +11,14 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         private static Version GetAssemblyVersion(string sourcePath)
         {
-            return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+            try
+            {
+                return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+            }
+            catch(BadImageFormatException)
+            {
+                return null;
+            }
         }
     }
 }

--- a/netstandard/tools/FileUtilities.netstandard.cs
+++ b/netstandard/tools/FileUtilities.netstandard.cs
@@ -10,7 +10,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public partial class HandlePackageFileConflicts : Task
+    static partial class FileUtilities
     {
         private static Version GetAssemblyVersion(string sourcePath)
         {

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -6,17 +6,20 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class HandlePackageFileConflicts : Task
     {
         private Dictionary<string, int> packageRanks = null;
+        private Dictionary<string, ConflictItem> externalRuntimeByFileName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ConflictItem> runtimeItemsByTargetPath = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
 
         public ITaskItem[] References { get; set; }
         
         public ITaskItem[] ReferenceCopyLocalPaths { get; set; }
+
+        public ITaskItem[] ExternalRuntimeItems { get; set; }
 
         /// <summary>
         /// NuGet3 and later only.  In the case of a conflict with identical file version information a file from the most preferred package will be chosen.
@@ -32,18 +35,15 @@ namespace Microsoft.DotNet.Build.Tasks
         public override bool Execute()
         {
             // remove References that will conflict at compile
-            var referencesWithoutConflicts = HandleConflicts(References, ItemUtilities.GetReferenceFileName);
+            var referencesWithoutConflicts = HandleReferenceConflicts(References);
 
-            // remove References that will conflict in output
-            Dictionary<string, ITaskItem> referencesByTargetPath;
-            referencesWithoutConflicts = HandleConflicts(referencesWithoutConflicts, ItemUtilities.GetReferenceTargetPath, out referencesByTargetPath);
+            LoadExternal();
 
-            // remove ReferenceCopyLocalPaths that will conflict in output.
-            Dictionary<string, ITaskItem> referenceCopyLocalPathsByTargetPath;
-            var referenceCopyLocalPathsWithoutConflicts = HandleConflicts(ReferenceCopyLocalPaths, ItemUtilities.GetTargetPath, out referenceCopyLocalPathsByTargetPath);
+            // remove References that will conflict in output or with externals.
+            referencesWithoutConflicts = HandleRuntimeConflicts(referencesWithoutConflicts, ConflictItemType.Reference, ItemUtilities.GetReferenceTargetPath);
 
-            // remove ReferenceCopyLocalPaths & set References to Private=false that will conflict in output.
-            referenceCopyLocalPathsWithoutConflicts = HandleConflicts(referenceCopyLocalPathsWithoutConflicts, referenceCopyLocalPathsByTargetPath, referencesByTargetPath);
+            // remove ReferenceCopyLocalPaths that will conflict in output or with externals.
+            var referenceCopyLocalPathsWithoutConflicts = HandleRuntimeConflicts(ReferenceCopyLocalPaths, ConflictItemType.CopyLocal, ItemUtilities.GetTargetPath);
 
             ReferencesWithoutConflicts = referencesWithoutConflicts;
             ReferenceCopyLocalPathsWithoutConflicts = referenceCopyLocalPathsWithoutConflicts;
@@ -73,17 +73,15 @@ namespace Microsoft.DotNet.Build.Tasks
             }
         }
 
-        private int GetPackageRank(ITaskItem item)
+        private int GetPackageRank(ConflictItem item)
         {
             int rank = int.MaxValue;
 
-            var packageId = item.GetMetadata("NuGetPackageId");
-
-            if (!String.IsNullOrWhiteSpace(packageId) && PreferredPackages != null)
+            if (item.PackageId != null && PreferredPackages != null)
             {
                 EnsurePackageRanks();
 
-                packageRanks.TryGetValue(packageId, out rank);
+                packageRanks.TryGetValue(item.PackageId, out rank);
             }
 
             return rank;
@@ -93,26 +91,41 @@ namespace Microsoft.DotNet.Build.Tasks
         /// Examines items for conflicting keys and chooses the best item.
         /// </summary>
         /// <param name="items">Items from which to remove conflicts</param>
-        /// <param name="getItemKey">Delegate to calculate key for an item</param>
         /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleConflicts(ITaskItem[] items, Func<ITaskItem, string> getItemKey)
+        private ITaskItem[] HandleReferenceConflicts(ITaskItem[] items)
         {
-            Dictionary<string, ITaskItem> itemsByKeyUnused;
+            Dictionary<string, ConflictItem> referenceByName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
 
-            return HandleConflicts(items, getItemKey, out itemsByKeyUnused);
+            return HandleConflicts(items, ConflictItemType.Reference, ItemUtilities.GetReferenceFileName, referenceByName);
         }
 
         /// <summary>
         /// Examines items for conflicting keys and chooses the best item.
         /// </summary>
         /// <param name="items">Items from which to remove conflicts</param>
+        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
+        /// <param name="getItemKey">Delegate to calculate key for an item</param>
+        /// <returns>Items without conflicts</returns>
+        private ITaskItem[] HandleRuntimeConflicts(ITaskItem[] items, ConflictItemType itemType, Func<ITaskItem, string> getItemKey)
+        {
+            return HandleConflicts(items, itemType, getItemKey, runtimeItemsByTargetPath, checkExternal:true);
+        }
+
+        /// <summary>
+        /// Examines items for conflicting keys and chooses the best item.
+        /// </summary>
+        /// <param name="items">Items from which to remove conflicts</param>
+        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
         /// <param name="getItemKey">Delegate to calculate key for an item</param>
         /// <param name="winningItemsByKey">Dictionary of items by key without conflicts</param>
+        /// <param name="checkExternal">If items should be checked for conflicts against external items</param>
         /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleConflicts(ITaskItem[] items, Func<ITaskItem, string> getItemKey, out Dictionary<string, ITaskItem> winningItemsByKey)
+        private ITaskItem[] HandleConflicts(ITaskItem[] items,
+                                            ConflictItemType itemType,
+                                            Func<ITaskItem, string> getItemKey,
+                                            Dictionary<string, ConflictItem> winningItemsByKey,
+                                            bool checkExternal = false)
         {
-            winningItemsByKey = new Dictionary<string, ITaskItem>(StringComparer.OrdinalIgnoreCase);
-
             if (items == null)
             {
                 return items;
@@ -130,12 +143,18 @@ namespace Microsoft.DotNet.Build.Tasks
                     continue;
                 }
 
-                ITaskItem existingItem;
+                ConflictItem existingItem, conflictItem = new ConflictItem(item, itemType);
+
+                if (checkExternal && HandleExternalConflict(conflictItem))
+                {
+                    conflictsToRemove.Add(item);
+                    continue;
+                }
 
                 if (winningItemsByKey.TryGetValue(itemKey, out existingItem))
                 {
                     // a conflict was found, determine the winner.
-                    var winner = HandleConflict(existingItem, item);
+                    var winner = HandleConflict(existingItem, conflictItem);
 
                     if (winner == null)
                     {
@@ -146,9 +165,24 @@ namespace Microsoft.DotNet.Build.Tasks
 
                     if (!ReferenceEquals(winner, existingItem))
                     {
-                        // replace existing item and add it to conflict list.
-                        winningItemsByKey[itemKey] = item;
-                        conflictsToRemove.Add(existingItem);
+                        // replace existing item
+                        winningItemsByKey[itemKey] = conflictItem;
+
+                        if (existingItem.ItemType == itemType)
+                        {
+                            // same type as we're currently processing remove it from item list
+                            conflictsToRemove.Add(existingItem.OriginalItem);
+                        }
+                        else if (existingItem.ItemType == ConflictItemType.Reference)
+                        {
+                            // Existing item is a Reference and winning item is CopyLocal or External
+                            // make the Reference not private, so that it will not copy-local
+                            existingItem.OriginalItem.SetMetadata("Private", "False");
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Internal error. Cannot remove item from {existingItem.ItemType} when processing {itemType}.");
+                        }
                     }
                     else
                     {
@@ -158,96 +192,46 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
                 else
                 {
-                    winningItemsByKey[itemKey] = item;
+                    winningItemsByKey[itemKey] = conflictItem;
                 }
             }
 
             return RemoveConflicts(items, conflictsToRemove);
         }
 
-        /// <summary>
-        /// Examines private (copy-local) references amd referenceCopyLocalPaths for inter-conflicts and
-        /// demotes references to non-private or removes items from referenceCopyLocalPaths.
-        /// </summary>
-        /// <param name="referenceCopyLocalPaths">ReferenceCopyLocalPaths item, already filtered for intra-conflicts</param>
-        /// <param name="referenceCopyLocalPathsByTargetPath">ReferenceCopyLocalPaths already filtered for intra-conflicts, indexed by TargetPath</param>
-        /// <param name="referencesByTargetPath">References item for private references, already filtered for compile-time intra-conflicts and copy-local intra-conflicts, indexed by TargetPath.  Items within this collection will be modified as neecessary to handle conflicts with ReferenceCopyLocalPaths by making the reference Private=false.</param>
-        /// <returns>ReferenceCopyLocalPaths item filtered for inter-conflicts with References</returns>
-        private ITaskItem[] HandleConflicts(ITaskItem[] referenceCopyLocalPaths, Dictionary<string, ITaskItem> referenceCopyLocalPathsByTargetPath, Dictionary<string, ITaskItem> referencesByTargetPath)
+        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2)
         {
-            if (referencesByTargetPath.Count == 0 || referenceCopyLocalPathsByTargetPath.Count == 0)
-            {
-                // nothing to do if either item set doesn't have targetpaths
-                return referenceCopyLocalPaths;
-            }
-
-            // ensure we use reference equality and not any overridden equality operators on items
-            var conflictsToRemove = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
-
-            // find conflicts between the two, arbitrarily choose ref to iterate over
-            foreach (var referenceByTargetPath in referencesByTargetPath)
-            {
-                var targetPath = referenceByTargetPath.Key;
-                var reference = referenceByTargetPath.Value;
-
-                ITaskItem referenceCopyLocalPath = null;
-
-                if (referenceCopyLocalPathsByTargetPath.TryGetValue(targetPath, out referenceCopyLocalPath))
-                {
-                    // a conflict was found, determine the winner.
-                    var winner = HandleConflict(reference, referenceCopyLocalPath);
-
-                    if (winner == null)
-                    {
-                        // no winner, skip it.
-                        continue;
-                    }
-
-                    if (ReferenceEquals(winner, referenceCopyLocalPath))
-                    {
-                        // ReferenceCopyLocalPath won, make the reference not private, so that it will not copy-local
-                        reference.SetMetadata("Private", "False");
-                    }
-                    else
-                    {
-                        // Reference won, remove the copy-local item.
-                        conflictsToRemove.Add(referenceCopyLocalPath);
-                    }
-                }
-            }
-            
-            return RemoveConflicts(referenceCopyLocalPaths, conflictsToRemove);
+            bool unused;
+            return HandleConflict(item1, item2, out unused);
         }
 
-        private ITaskItem HandleConflict(ITaskItem item1, ITaskItem item2)
+        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2, out bool equal)
         {
-            var conflictMessage = $"Encountered conflict between {item1.ItemSpec} and {item2.ItemSpec}.";
+            equal = false;
+            var conflictMessage = $"Encountered conflict between {item1.DisplayName} and {item2.DisplayName}.";
 
-            var sourcePath1 = ItemUtilities.GetSourcePath(item1);
-            var sourcePath2 = ItemUtilities.GetSourcePath(item2);
-
-            var exists1 = File.Exists(sourcePath1);
-            var exists2 = File.Exists(sourcePath2);
+            var exists1 = item1.Exists;
+            var exists2 = item2.Exists;
 
             if (!exists1 || !exists2)
             {
                 var fileMessage = !exists1 ?
                                     !exists2 ? 
                                       "both files do" :
-                                      $"{item1.ItemSpec} does" :
-                                  $"{item2.ItemSpec} does";
+                                      $"{item1.DisplayName} does" :
+                                  $"{item2.DisplayName} does";
 
                 Log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
                 return null;
             }
-            
-            var assemblyVersion1 = FileUtilities.TryGetAssemblyVersion(sourcePath1);
-            var assemblyVersion2 = FileUtilities.TryGetAssemblyVersion(sourcePath2);
+
+            var assemblyVersion1 = item1.AssemblyVersion;
+            var assemblyVersion2 = item2.AssemblyVersion;
 
             // if only one is missing version stop: something is wrong when we have a conflict between assembly and non-assembly
             if (assemblyVersion1 == null ^ assemblyVersion2 == null)
             {
-                var nonAssembly = assemblyVersion1 == null ? item1.ItemSpec : item2.ItemSpec;
+                var nonAssembly = assemblyVersion1 == null ? item1.DisplayName : item2.DisplayName;
                 Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
                 return null;
             }
@@ -257,24 +241,24 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (assemblyVersion1 > assemblyVersion2)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
                     return item1;
                 }
 
                 if (assemblyVersion2 > assemblyVersion1)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
                     return item2;
                 }
             }
 
-            var fileVersion1 = FileUtilities.GetFileVersion(sourcePath1);
-            var fileVersion2 = FileUtilities.GetFileVersion(sourcePath2);
+            var fileVersion1 = item1.FileVersion;
+            var fileVersion2 = item2.FileVersion;
 
             // if only one is missing version
             if (fileVersion1 == null ^ fileVersion2 == null)
             {
-                var nonVersion = fileVersion1 == null ? item1.ItemSpec : item2.ItemSpec;
+                var nonVersion = fileVersion1 == null ? item1.DisplayName : item2.DisplayName;
                 Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
                 return null;
             }
@@ -283,13 +267,13 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (fileVersion1 > fileVersion2)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because file version {fileVersion1} is greater than {fileVersion2}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because file version {fileVersion1} is greater than {fileVersion2}.");
                     return item1;
                 }
 
                 if (fileVersion2 > fileVersion1)
                 {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because file version {fileVersion2} is greater than {fileVersion1}.");
+                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because file version {fileVersion2} is greater than {fileVersion1}.");
                     return item2;
                 }
             }
@@ -299,18 +283,63 @@ namespace Microsoft.DotNet.Build.Tasks
 
             if (packageRank1 < packageRank2)
             {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item1.ItemSpec} because package it comes from a package that is preferred.");
+                Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because package it comes from a package that is preferred.");
                 return item1;
             }
 
             if (packageRank2 < packageRank1)
             {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item2.ItemSpec} because package it comes from a package that is preferred.");
+                Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is preferred.");
                 return item2;
             }
 
             Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
+            equal = true;
             return null;
+        }
+
+        private bool HandleExternalConflict(ConflictItem item)
+        {
+            ConflictItem externalItem;
+
+            if (externalRuntimeByFileName.TryGetValue(item.FileName, out externalItem))
+            {
+                bool equal;
+                var winner = HandleConflict(item, externalItem, out equal);
+
+                if (winner == externalItem || equal)
+                {
+                    return true;
+                }
+                else if (winner == item)
+                {
+                    externalRuntimeByFileName.Remove(item.FileName);
+                }
+            }
+
+            return false;
+        }
+
+        private void LoadExternal()
+        {
+            if (ExternalRuntimeItems == null)
+            {
+                return;
+            }
+
+            foreach(var externalItem in ExternalRuntimeItems)
+            {
+                ConflictItem existingItem, conflictItem = new ConflictItem(externalItem, ConflictItemType.External);
+
+                if (!externalRuntimeByFileName.TryGetValue(conflictItem.FileName, out existingItem) ||
+                    HandleConflict(existingItem, conflictItem) == conflictItem)
+                {
+                    // we only care about the winners for external items
+                    // the losers are redundant since we only use this map
+                    // to determine if Reference/CopyLocal should be trimmed.
+                    externalRuntimeByFileName[conflictItem.FileName] = conflictItem;
+                }
+            }
         }
 
         /// <summary>

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -77,21 +77,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             int rank = int.MaxValue;
 
-            // NuGet 3
             var packageId = item.GetMetadata("NuGetPackageId");
-
-            if (String.IsNullOrWhiteSpace(packageId))
-            {
-                // NuGet 4
-                packageId = item.GetMetadata("ParentPackage");
-
-                var versionSeparatorIndex = packageId.IndexOf('/');
-
-                if (versionSeparatorIndex != -1)
-                {
-                    packageId = packageId.Substring(0, versionSeparatorIndex);
-                }
-            }
 
             if (!String.IsNullOrWhiteSpace(packageId) && PreferredPackages != null)
             {

--- a/netstandard/tools/ItemUtilities.cs
+++ b/netstandard/tools/ItemUtilities.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class ItemUtilities
+    {
+        /// <summary>
+        /// Get's the filename to use for identifying reference conflicts
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static string GetReferenceFileName(ITaskItem item)
+        {
+            var aliases = item.GetMetadata("Aliases");
+
+            if (!String.IsNullOrEmpty(aliases))
+            {
+                // skip compile-time conflict detection for aliased assemblies.
+                // An alias is the way to avoid a conflict
+                //   eg: System, v1.0.0.0 in global will not conflict with System, v2.0.0.0 in `private` alias
+                // We could model each alias scope and try to check for conflicts within that scope,
+                // but this is a ton of complexity for a fringe feature.
+                // Instead, we'll treat an alias as an indication that the developer has opted out of 
+                // conflict resolution.
+                return null;
+            }
+
+            // We only handle references that have path information since we're only concerned
+            // with resolving conflicts between file references.  If conflicts exist between 
+            // named references that are found from AssemblySearchPaths we'll leave those to
+            // RAR to handle or not as it sees fit.
+            var sourcePath = GetSourcePath(item);
+
+            if (String.IsNullOrEmpty(sourcePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Path.GetFileName(sourcePath);
+            }
+            catch (ArgumentException)
+            {
+                // We won't even try to resolve a conflict if we can't open the file, so ignore invalid paths
+                return null;
+            }
+        }
+
+        public static string GetReferenceTargetPath(ITaskItem item)
+        {
+            // Determine if the reference will be copied local.  
+            // We're only dealing with primary file references.  For these RAR will 
+            // copy local if Private is true or unset.
+
+            var isPrivate = MSBuildUtilities.ConvertStringToBool(item.GetMetadata("Private"), defaultValue: true);
+
+            if (!isPrivate)
+            {
+                // Private = false means the reference shouldn't be copied.
+                return null;
+            }
+
+            return GetTargetPath(item);
+        }
+
+        public static string GetSourcePath(ITaskItem item)
+        {
+            var sourcePath = item.GetMetadata("HintPath");
+
+            if (String.IsNullOrWhiteSpace(sourcePath))
+            {
+                // assume item-spec points to the file.
+                // this won't work if it comes from a targeting pack or SDK, but
+                // in that case the file won't exist and we'll skip it.
+                sourcePath = item.ItemSpec;
+            }
+
+            return sourcePath;
+        }
+
+        static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "DestinationSubPath", "Path" };
+        public static string GetTargetPath(ITaskItem item)
+        {
+            // first use TargetPath, DestinationSubPath, then Path, then fallback to filename+extension alone
+            foreach (var metadata in s_targetPathMetadata)
+            {
+                var value = item.GetMetadata(metadata);
+
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    // normalize path
+                    return value.Replace('\\', '/');
+                }
+            }
+
+            var sourcePath = GetSourcePath(item);
+
+            return Path.GetFileName(sourcePath);
+        }
+    }
+}

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
     <Compile Include="ItemUtilities.cs" />
+    <Compile Include="ConflictItem.cs" />
     <Compile Include="HandlePackageFileConflicts.cs" />
     <Compile Include="FileUtilities.cs" />
     <Compile Include="MSBuildUtilities.cs" />

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -11,16 +11,18 @@
   <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
+    <Compile Include="ItemUtilities.cs" />
     <Compile Include="HandlePackageFileConflicts.cs" />
+    <Compile Include="FileUtilities.cs" />
     <Compile Include="MSBuildUtilities.cs" />
     <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
-    <Compile Include="HandlePackageFileConflicts.netstandard.cs" />
+    <Compile Include="FileUtilities.netstandard.cs" />
     <PackageDestination Include="build" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
-    <Compile Include="HandlePackageFileConflicts.net45.cs" />
+    <Compile Include="FileUtilities.net45.cs" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="Microsoft.Build" />

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -29,6 +29,7 @@
     <TargetingPackReference Include="Microsoft.Build" />
     <TargetingPackReference Include="Microsoft.Build.Framework" />
     <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
+    <TargetingPackReference Include="System.Runtime" />
     <PackageDestination Include="build/desktop" />
   </ItemGroup>
   <ItemGroup>

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -55,6 +55,7 @@
   <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
     <HandlePackageFileConflicts References="@(Reference)"
                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+                                ExternalRuntimeItems="@(PackageConflictExternalRuntimeItems)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <Choose>
+    <!-- Allow completely disabling the conflict resolution targets-->
+    <When Condition="'$(DisableHandlePackageFileConflicts)' == 'true'" />
     <!-- Condition here is a hack until https://github.com/dotnet/sdk/issues/534 is fixed -->
     <When Condition="'$(TargetFramework)' != '' or '$(TargetFrameworks)' != ''">
       <!-- NuGet 4, run after the targets that construct items from deps -->
@@ -55,7 +57,8 @@
   <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
     <HandlePackageFileConflicts References="@(Reference)"
                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                                ExternalRuntimeItems="@(PackageConflictExternalRuntimeItems)"
+                                PlatformItems="@(PackageConflictPlatformItems)"
+                                PlatformManifests="@(PackageConflictPlatformManifests)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
@@ -75,6 +78,8 @@
 
   <Target Name="HandlePublishFileConflicts" AfterTargets="$(HandlePublishFileConflictsAfter)">
     <HandlePackageFileConflicts ReferenceCopyLocalPaths="@(ResolvedAssembliesToPublish)"
+                                PlatformItems="@(PackageConflictPlatformItems)"
+                                PlatformManifests="@(PackageConflictPlatformManifests)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ResolvedAssembliesToPublishWithoutConflicts" />
     </HandlePackageFileConflicts>


### PR DESCRIPTION
This is needed to support the shared framework.  It will have many files that are never seen when restoring without a RID but need to be considered for conflict resolution since past packages included them when restoring without a RID.  Even barring the RID specific-ness we should represent the entire shared framework through this mechanism so that we can remove files even if folks directly reference RID-specific packages.

/cc @weshaggard @terrajobst @eerhardt 

best reviewed commit-by-commit.