### PR TITLE
Remove finalizers on sealed types from the netstandard ref

### DIFF
--- a/netstandard/ref/System.Core.cs
+++ b/netstandard/ref/System.Core.cs
@@ -433,7 +433,6 @@ namespace System.IO.Pipes
         public AnonymousPipeClientStream(string pipeHandleAsString) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         public override System.IO.Pipes.PipeTransmissionMode ReadMode { set { } }
         public override System.IO.Pipes.PipeTransmissionMode TransmissionMode { get { throw null; } }
-        ~AnonymousPipeClientStream() { }
     }
     public sealed partial class AnonymousPipeServerStream : System.IO.Pipes.PipeStream
     {
@@ -448,7 +447,6 @@ namespace System.IO.Pipes
         public override System.IO.Pipes.PipeTransmissionMode TransmissionMode { get { throw null; } }
         protected override void Dispose(bool disposing) { }
         public void DisposeLocalCopyOfClientHandle() { }
-        ~AnonymousPipeServerStream() { }
         public string GetClientHandleAsString() { throw null; }
     }
     public sealed partial class NamedPipeClientStream : System.IO.Pipes.PipeStream
@@ -469,7 +467,6 @@ namespace System.IO.Pipes
         public System.Threading.Tasks.Task ConnectAsync(int timeout) { throw null; }
         public System.Threading.Tasks.Task ConnectAsync(int timeout, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
-        ~NamedPipeClientStream() { }
     }
     public sealed partial class NamedPipeServerStream : System.IO.Pipes.PipeStream
     {
@@ -487,7 +484,6 @@ namespace System.IO.Pipes
         public System.IAsyncResult BeginWaitForConnection(System.AsyncCallback callback, object state) { throw null; }
         public void Disconnect() { }
         public void EndWaitForConnection(System.IAsyncResult asyncResult) { }
-        ~NamedPipeServerStream() { }
         public string GetImpersonationUserName() { throw null; }
         public void RunAsClient(System.IO.Pipes.PipeStreamImpersonationWorker impersonationWorker) { }
         public void WaitForConnection() { }

--- a/netstandard/ref/System.cs
+++ b/netstandard/ref/System.cs
@@ -1087,7 +1087,6 @@ namespace System.ComponentModel
         internal AsyncOperation() { }
         public System.Threading.SynchronizationContext SynchronizationContext { get { throw null; } }
         public object UserSuppliedState { get { throw null; } }
-        ~AsyncOperation() { }
         public void OperationCompleted() { }
         public void Post(System.Threading.SendOrPostCallback d, object arg) { }
         public void PostOperationCompleted(System.Threading.SendOrPostCallback d, object arg) { }

--- a/netstandard/ref/mscorlib.cs
+++ b/netstandard/ref/mscorlib.cs
@@ -2433,7 +2433,6 @@ namespace System
     public sealed partial class LocalDataStoreSlot
     {
         internal LocalDataStoreSlot() { }
-        ~LocalDataStoreSlot() { }
     }
     public abstract partial class MarshalByRefObject
     {
@@ -3931,7 +3930,6 @@ namespace System
     {
         public WeakReference(T target) { }
         public WeakReference(T target, bool trackResurrection) { }
-        ~WeakReference() { }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void SetTarget(T target) { }
         public bool TryGetTarget(out T target) { target = default(T); throw null; }
@@ -7443,7 +7441,6 @@ namespace System.IO.IsolatedStorage
         public bool DirectoryExists(string path) { throw null; }
         public void Dispose() { }
         public bool FileExists(string path) { throw null; }
-        ~IsolatedStorageFile() { }
         public System.DateTimeOffset GetCreationTime(string path) { throw null; }
         public string[] GetDirectoryNames() { throw null; }
         public string[] GetDirectoryNames(string searchPattern) { throw null; }
@@ -9162,7 +9159,6 @@ namespace System.Runtime
     {
         public MemoryFailPoint(int sizeInMegabytes) { }
         public void Dispose() { }
-        ~MemoryFailPoint() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(96), AllowMultiple=false, Inherited=false)]
     public sealed partial class TargetedPatchingOptOutAttribute : System.Attribute
@@ -9279,7 +9275,6 @@ namespace System.Runtime.CompilerServices
     {
         public ConditionalWeakTable() { }
         public void Add(TKey key, TValue value) { }
-        ~ConditionalWeakTable() { }
         public TValue GetOrCreateValue(TKey key) { throw null; }
         public TValue GetValue(TKey key, System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>.CreateValueCallback createValueCallback) { throw null; }
         public bool Remove(TKey key) { throw null; }
@@ -13693,7 +13688,6 @@ namespace System.Threading
         public void AcquireWriterLock(System.TimeSpan timeout) { }
         public bool AnyWritersSince(int seqNum) { throw null; }
         public void DowngradeFromWriterLock(ref System.Threading.LockCookie lockCookie) { }
-        ~ReaderWriterLock() { }
         public System.Threading.LockCookie ReleaseLock() { throw null; }
         public void ReleaseReaderLock() { }
         public void ReleaseWriterLock() { }
@@ -13818,7 +13812,6 @@ namespace System.Threading
         public void DisableComObjectEagerCleanup() { }
         public static void EndCriticalRegion() { }
         public static void EndThreadAffinity() { }
-        ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
         [System.ObsoleteAttribute("Thread.GetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]


### PR DESCRIPTION
These finalizers aren't necessary in reference assemblies for
sealed types.

Fixes https://github.com/dotnet/standard/issues/122.

@stephentoub PTAL