### PR TITLE
ConflictResolver + deps trimming

### DIFF
--- a/netstandard/tools/ConflictPlatformItem.cs
+++ b/netstandard/tools/ConflictPlatformItem.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    // An IConflictItem that represents a platform item constructed from a data file.
+    class ConflictPlatformItem : IConflictItem
+    {
+        public ConflictPlatformItem(string fileName, string packageId, Version assemblyVersion, Version fileVersion)
+        {
+            FileName = fileName;
+            SourcePath = fileName;
+            PackageId = packageId;
+            AssemblyVersion = assemblyVersion;
+            FileVersion = fileVersion;
+
+            DisplayName = "Platform:" + fileName;
+            Exists = true;
+        }
+
+        public Version AssemblyVersion { get; }
+        
+        public string DisplayName { get; }
+
+        public bool Exists { get; }
+
+        public string FileName { get; }
+
+        public Version FileVersion { get; }
+
+        public bool IsPlatform {  get { return true; } }
+
+        public string PackageId { get; }
+
+        public string SourcePath { get; }
+
+        static readonly char[] s_manifestLineSeparator = new[] { '|' };
+        public static IEnumerable<ConflictPlatformItem> LoadPlatformManifest(string manifestPath, ILog log)
+        {
+            if (manifestPath == null)
+            {
+                throw new ArgumentNullException(nameof(manifestPath));
+            }
+
+            if (!File.Exists(manifestPath))
+            {
+                log.LogError($"Could not load PlatformManifest from {manifestPath} because it did not exist");
+                yield break;
+            }
+
+            using (var manfiestStream = File.Open(manifestPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            using (var manifestReader = new StreamReader(manfiestStream))
+            {
+                for (int lineNumber = 0; !manifestReader.EndOfStream; lineNumber++)
+                {
+                    var line = manifestReader.ReadLine().Trim();
+
+                    if (line.Length == 0 || line[0] == '#')
+                    {
+                        continue;
+                    }
+
+                    var lineParts = line.Split(s_manifestLineSeparator);
+
+                    if (lineParts.Length != 4)
+                    {
+                        log.LogError($"Error parsing PlatformManifest from {manifestPath} line {lineNumber}.  Lines must have the format fileName|packageId|assemblyVersion|fileVersion");
+                        yield break;
+                    }
+
+                    var fileName = lineParts[0].Trim();
+                    var packageId = lineParts[1].Trim();
+                    var assemblyVersionString = lineParts[2].Trim();
+                    var fileVersionString = lineParts[3].Trim();
+
+                    Version assemblyVersion = null, fileVersion = null;
+
+                    if (assemblyVersionString.Length != 0 && !Version.TryParse(assemblyVersionString, out assemblyVersion))
+                    {
+                        log.LogError($"Error parsing PlatformManfiest from {manifestPath} line {lineNumber}.  AssemblyVersion {assemblyVersionString} was invalid.");
+                    }
+
+                    if (fileVersionString.Length != 0 && !Version.TryParse(fileVersionString, out fileVersion))
+                    {
+                        log.LogError($"Error parsing PlatformManifest from {manifestPath} line {lineNumber}.  FileVersion {fileVersionString} was invalid.");
+                    }
+
+                    yield return new ConflictPlatformItem(fileName, packageId, assemblyVersion, fileVersion);
+                }
+            }
+        }
+    }
+}

--- a/netstandard/tools/ConflictResolver.cs
+++ b/netstandard/tools/ConflictResolver.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    class ConflictResolver
+    {
+        private Dictionary<string, IConflictItem> winningItemsByKey = new Dictionary<string, IConflictItem>();
+        private ILog log;
+        private PackageRank packageRank;
+
+        public ConflictResolver(PackageRank packageRank, ILog log)
+        {
+            this.log = log;
+            this.packageRank = packageRank;
+        }
+
+        public void ResolveConflicts<T>(IEnumerable<T> conflictItems, Func<T, string> getItemKey, Action<IConflictItem> foundConflict) where T: IConflictItem
+        {
+            if (conflictItems == null)
+            {
+                return;
+            }
+
+            foreach (var conflictItem in conflictItems)
+            {
+                var itemKey = getItemKey(conflictItem);
+
+                if (String.IsNullOrEmpty(itemKey))
+                {
+                    continue;
+                }
+
+                IConflictItem existingItem;
+
+                if (winningItemsByKey.TryGetValue(itemKey, out existingItem))
+                {
+                    // a conflict was found, determine the winner.
+                    var winner = ResolveConflict(existingItem, conflictItem);
+
+                    if (winner == null)
+                    {
+                        // no winner, skip it.
+                        // don't add to conflict list and just use the existing item for future conflicts.
+                        continue;
+                    }
+
+                    IConflictItem loser = conflictItem;
+                    if (!ReferenceEquals(winner, existingItem))
+                    {
+                        // replace existing item
+                        winningItemsByKey[itemKey] = conflictItem;
+                        loser = existingItem;
+
+                    }
+
+                    foundConflict(loser);
+                }
+                else
+                {
+                    winningItemsByKey[itemKey] = conflictItem;
+                }
+            }
+        }
+
+        private IConflictItem ResolveConflict(IConflictItem item1, IConflictItem item2)
+        {
+            var conflictMessage = $"Encountered conflict between {item1.DisplayName} and {item2.DisplayName}.";
+
+            var exists1 = item1.Exists;
+            var exists2 = item2.Exists;
+
+            if (!exists1 || !exists2)
+            {
+                var fileMessage = !exists1 ?
+                                    !exists2 ?
+                                      "both files do" :
+                                      $"{item1.DisplayName} does" :
+                                  $"{item2.DisplayName} does";
+
+                log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
+                return null;
+            }
+
+            var assemblyVersion1 = item1.AssemblyVersion;
+            var assemblyVersion2 = item2.AssemblyVersion;
+
+            // if only one is missing version stop: something is wrong when we have a conflict between assembly and non-assembly
+            if (assemblyVersion1 == null ^ assemblyVersion2 == null)
+            {
+                var nonAssembly = assemblyVersion1 == null ? item1.DisplayName : item2.DisplayName;
+                log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
+                return null;
+            }
+
+            // only handle cases where assembly version is different, and not null (implicit here due to xor above)
+            if (assemblyVersion1 != assemblyVersion2)
+            {
+                if (assemblyVersion1 > assemblyVersion2)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
+                    return item1;
+                }
+
+                if (assemblyVersion2 > assemblyVersion1)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
+                    return item2;
+                }
+            }
+
+            var fileVersion1 = item1.FileVersion;
+            var fileVersion2 = item2.FileVersion;
+
+            // if only one is missing version
+            if (fileVersion1 == null ^ fileVersion2 == null)
+            {
+                var nonVersion = fileVersion1 == null ? item1.DisplayName : item2.DisplayName;
+                log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
+                return null;
+            }
+
+            if (fileVersion1 != fileVersion2)
+            {
+                if (fileVersion1 > fileVersion2)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because file version {fileVersion1} is greater than {fileVersion2}.");
+                    return item1;
+                }
+
+                if (fileVersion2 > fileVersion1)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because file version {fileVersion2} is greater than {fileVersion1}.");
+                    return item2;
+                }
+            }
+
+            var packageRank1 = packageRank.GetPackageRank(item1.PackageId);
+            var packageRank2 = packageRank.GetPackageRank(item2.PackageId);
+
+            if (packageRank1 < packageRank2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because package it comes from a package that is preferred.");
+                return item1;
+            }
+
+            if (packageRank2 < packageRank1)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is preferred.");
+                return item2;
+            }
+
+            var isPlatform1 = item1.IsPlatform;
+            var isPlatform2 = item2.IsPlatform;
+
+            if (isPlatform1 && !isPlatform2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because it is a platform item.");
+                return item1;
+            }
+
+            if (!isPlatform1 && isPlatform2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because it is a platform item.");
+                return item1;
+            }
+
+            log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
+            return null;
+        }
+    }
+}

--- a/netstandard/tools/ConflictResolver.cs
+++ b/netstandard/tools/ConflictResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks
             this.packageRank = packageRank;
         }
 
-        public void ResolveConflicts<T>(IEnumerable<T> conflictItems, Func<T, string> getItemKey, Action<IConflictItem> foundConflict) where T: IConflictItem
+        public void ResolveConflicts<T>(IEnumerable<T> conflictItems, Func<T, string> getItemKey, Action<IConflictItem> foundConflict, bool commitWinner = true) where T: IConflictItem
         {
             if (conflictItems == null)
             {
@@ -54,14 +54,21 @@ namespace Microsoft.DotNet.Build.Tasks
                     if (!ReferenceEquals(winner, existingItem))
                     {
                         // replace existing item
-                        winningItemsByKey[itemKey] = conflictItem;
+                        if (commitWinner)
+                        {
+                            winningItemsByKey[itemKey] = conflictItem;
+                        }
+                        else
+                        {
+                            winningItemsByKey.Remove(itemKey);
+                        }
                         loser = existingItem;
 
                     }
 
                     foundConflict(loser);
                 }
-                else
+                else if (commitWinner)
                 {
                     winningItemsByKey[itemKey] = conflictItem;
                 }

--- a/netstandard/tools/ConflictTaskItem.cs
+++ b/netstandard/tools/ConflictTaskItem.cs
@@ -11,28 +11,16 @@ namespace Microsoft.DotNet.Build.Tasks
     internal enum ConflictItemType
     {
         Reference,
-        CopyLocal,
-        Platform
+        CopyLocal
     }
 
-    // Wraps an ITask item and adds lazy evaluated properties used by Conflict resolution.
-    internal class ConflictItem
+    // An IConflictItem that represents an MSBuild ITaskItem, either a reference or a copy-local item.
+    internal class ConflictTaskItem : IConflictItem
     {
-        public ConflictItem(ITaskItem originalItem, ConflictItemType itemType)
+        public ConflictTaskItem(ITaskItem originalItem, ConflictItemType itemType)
         {
             OriginalItem = originalItem;
             ItemType = itemType;
-        }
-
-        public ConflictItem(string fileName, string packageId, Version assemblyVersion, Version fileVersion)
-        {
-            OriginalItem = null;
-            ItemType = ConflictItemType.Platform;
-            FileName = fileName;
-            SourcePath = fileName;
-            PackageId = packageId;
-            AssemblyVersion = assemblyVersion;
-            FileVersion = fileVersion;
         }
 
         private bool hasAssemblyVersion;
@@ -78,7 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (exists == null)
                 {
-                    exists = ItemType == ConflictItemType.Platform || File.Exists(SourcePath);
+                    exists = File.Exists(SourcePath);
                 }
 
                 return exists.Value;
@@ -132,6 +120,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 hasFileVersion = true;
             }
         }
+
+        public bool IsPlatform { get { return false; } }
 
         public ITaskItem OriginalItem { get; }
 

--- a/netstandard/tools/ConflictTaskItem.cs
+++ b/netstandard/tools/ConflictTaskItem.cs
@@ -11,7 +11,8 @@ namespace Microsoft.DotNet.Build.Tasks
     internal enum ConflictItemType
     {
         Reference,
-        CopyLocal
+        CopyLocal,
+        Runtime
     }
 
     // An IConflictItem that represents an MSBuild ITaskItem, either a reference or a copy-local item.
@@ -133,6 +134,11 @@ namespace Microsoft.DotNet.Build.Tasks
                 if (packageId == null)
                 {
                     packageId = OriginalItem?.GetMetadata("NuGetPackageId") ?? String.Empty;
+
+                    if (packageId.Length == 0)
+                    {
+                        packageId = NuGetUtilities.GetPackageIdFromSourcePath(SourcePath) ?? String.Empty;
+                    }
                 }
 
                 return packageId.Length == 0 ? null : packageId;

--- a/netstandard/tools/FileUtilities.netstandard.cs
+++ b/netstandard/tools/FileUtilities.netstandard.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Build.Utilities;
 using System;
 using System.IO;
 using System.Reflection.Metadata;

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -6,24 +6,19 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class HandlePackageFileConflicts : Task
     {
-        static readonly char[] s_manifestLineSeparator = new[] { '|' };
-        private Dictionary<string, int> packageRanks = null;
-        private Dictionary<string, ConflictItem> platformRuntimeByFileName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
-        private Dictionary<string, ConflictItem> runtimeItemsByTargetPath = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
+        HashSet<ITaskItem> referenceConflicts = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
+        HashSet<ITaskItem> copyLocalConflicts = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
 
         public ITaskItem[] References { get; set; }
 
         public ITaskItem[] ReferenceCopyLocalPaths { get; set; }
-
-        public ITaskItem[] PlatformItems { get; set; }
-
+        
         public ITaskItem[] PlatformManifests { get; set; }
 
         /// <summary>
@@ -39,378 +34,70 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            // remove References that will conflict at compile
-            var referencesWithoutConflicts = HandleReferenceConflicts(References);
+            var log = new MSBuildLog(Log);
+            var packageRanks = new PackageRank(PreferredPackages);
 
-            LoadPlatform();
+            var referenceItems = References.Select(r => new ConflictTaskItem(r, ConflictItemType.Reference)).ToArray();
 
-            // remove References that will conflict in output or with platform items.
-            referencesWithoutConflicts = HandleRuntimeConflicts(referencesWithoutConflicts, ConflictItemType.Reference, ItemUtilities.GetReferenceTargetPath);
+            var compileConflictScope = new ConflictResolver(packageRanks, log);
 
-            // remove ReferenceCopyLocalPaths that will conflict in output or with platform items.
-            var referenceCopyLocalPathsWithoutConflicts = HandleRuntimeConflicts(ReferenceCopyLocalPaths, ConflictItemType.CopyLocal, ItemUtilities.GetTargetPath);
+            compileConflictScope.ResolveConflicts(referenceItems, 
+                ci => ItemUtilities.GetReferenceFileName(ci.OriginalItem),
+                HandleCompileConflict);
 
-            ReferencesWithoutConflicts = referencesWithoutConflicts;
-            ReferenceCopyLocalPathsWithoutConflicts = referenceCopyLocalPathsWithoutConflicts;
+            var runtimeConflictScope = new ConflictResolver(packageRanks, log);
+
+            runtimeConflictScope.ResolveConflicts(referenceItems,
+                ci => ItemUtilities.GetReferenceTargetPath(ci.OriginalItem),
+                HandleRuntimeConflict);
+
+            var copyLocalItems = ReferenceCopyLocalPaths.Select(c => new ConflictTaskItem(c, ConflictItemType.CopyLocal)).ToArray();
+
+            runtimeConflictScope.ResolveConflicts(copyLocalItems,
+                ci => ItemUtilities.GetTargetPath(ci.OriginalItem),
+                HandleRuntimeConflict);
+
+            var platformConflictScope = new ConflictResolver(packageRanks, log);
+            var platformItems = PlatformManifests.SelectMany(pm => ConflictPlatformItem.LoadPlatformManifest(pm.ItemSpec, log));
+
+            platformConflictScope.ResolveConflicts(platformItems, pi => pi.FileName, pi => { });
+            platformConflictScope.ResolveConflicts(referenceItems.Where(ri => !referenceConflicts.Contains(ri.OriginalItem)),
+                                                   ri => ri.FileName,
+                                                   HandleRuntimeConflict);
+            platformConflictScope.ResolveConflicts(copyLocalItems.Where(ci => !copyLocalConflicts.Contains(ci.OriginalItem)),
+                                                   ri => ri.FileName,
+                                                   HandleRuntimeConflict);
+
+            ReferencesWithoutConflicts = RemoveConflicts(References, referenceConflicts);
+            ReferenceCopyLocalPathsWithoutConflicts = RemoveConflicts(ReferenceCopyLocalPaths, copyLocalConflicts);
 
             return !Log.HasLoggedErrors;
         }
 
-        private void EnsurePackageRanks()
+        private void HandleCompileConflict(IConflictItem conflictItem)
         {
-            if (packageRanks == null)
+            var conflictTaskItem = conflictItem as ConflictTaskItem;
+            if (conflictTaskItem != null)
             {
-                var numPreferredPackages = PreferredPackages?.Length ?? 0;
-
-                // cache ranks for fast lookup
-                packageRanks = new Dictionary<string, int>(numPreferredPackages, StringComparer.OrdinalIgnoreCase);
-
-                for (int i = numPreferredPackages - 1; i >= 0 ; i--)
+                if (conflictTaskItem.ItemType == ConflictItemType.Reference)
                 {
-                    var preferredPackageId = PreferredPackages[i].Trim();
-
-                    if (preferredPackageId.Length != 0)
-                    {
-                        // overwrite any duplicates, lowest rank will win.
-                        packageRanks[preferredPackageId] = i;
-                    }
+                    referenceConflicts.Add(conflictTaskItem.OriginalItem);
                 }
             }
         }
 
-        private int GetPackageRank(ConflictItem item)
+        private void HandleRuntimeConflict(IConflictItem conflictItem)
         {
-            int rank = int.MaxValue;
-
-            if (item.PackageId != null && PreferredPackages != null)
+            var conflictTaskItem = conflictItem as ConflictTaskItem;
+            if (conflictTaskItem != null)
             {
-                EnsurePackageRanks();
-
-                packageRanks.TryGetValue(item.PackageId, out rank);
-            }
-
-            return rank;
-        }
-
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleReferenceConflicts(ITaskItem[] items)
-        {
-            Dictionary<string, ConflictItem> referenceByName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
-
-            return HandleConflicts(items, ConflictItemType.Reference, ItemUtilities.GetReferenceFileName, referenceByName);
-        }
-
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
-        /// <param name="getItemKey">Delegate to calculate key for an item</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleRuntimeConflicts(ITaskItem[] items, ConflictItemType itemType, Func<ITaskItem, string> getItemKey)
-        {
-            return HandleConflicts(items, itemType, getItemKey, runtimeItemsByTargetPath, checkPlatform:true);
-        }
-
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
-        /// <param name="getItemKey">Delegate to calculate key for an item</param>
-        /// <param name="winningItemsByKey">Dictionary of items by key without conflicts</param>
-        /// <param name="checkPlatform">If items should be checked for conflicts against platform items</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleConflicts(ITaskItem[] items,
-                                            ConflictItemType itemType,
-                                            Func<ITaskItem, string> getItemKey,
-                                            Dictionary<string, ConflictItem> winningItemsByKey,
-                                            bool checkPlatform = false)
-        {
-            if (items == null)
-            {
-                return items;
-            }
-
-            // ensure we use reference equality and not any overridden equality operators on items
-            var conflictsToRemove = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
-
-            foreach (var item in items)
-            {
-                var itemKey = getItemKey(item);
-
-                if (String.IsNullOrEmpty(itemKey))
+                if (conflictTaskItem.ItemType == ConflictItemType.Reference)
                 {
-                    continue;
-                }
-
-                ConflictItem existingItem, conflictItem = new ConflictItem(item, itemType);
-
-                if (checkPlatform && HandleExternalConflict(conflictItem))
-                {
-                    conflictsToRemove.Add(item);
-                    continue;
-                }
-
-                if (winningItemsByKey.TryGetValue(itemKey, out existingItem))
-                {
-                    // a conflict was found, determine the winner.
-                    var winner = HandleConflict(existingItem, conflictItem);
-
-                    if (winner == null)
-                    {
-                        // no winner, skip it.
-                        // don't add to conflict list and just use the existing item for future conflicts.
-                        continue;
-                    }
-
-                    if (!ReferenceEquals(winner, existingItem))
-                    {
-                        // replace existing item
-                        winningItemsByKey[itemKey] = conflictItem;
-
-                        if (existingItem.ItemType == itemType)
-                        {
-                            if (existingItem.OriginalItem != null)
-                            {
-                                // same type as we're currently processing remove it from item list
-                                conflictsToRemove.Add(existingItem.OriginalItem);
-                            }
-                        }
-                        else if (existingItem.ItemType == ConflictItemType.Reference)
-                        {
-                            if (existingItem.OriginalItem != null)
-                            {
-                                // Existing item is a Reference and winning item is CopyLocal or External
-                                // make the Reference not private, so that it will not copy-local
-                                existingItem.OriginalItem.SetMetadata("Private", "False");
-                            }
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException($"Internal error. Cannot remove item from {existingItem.ItemType} when processing {itemType}.");
-                        }
-                    }
-                    else
-                    {
-                        // no need to replace item, just add new item to conflict list.
-                        conflictsToRemove.Add(item);
-                    }
+                    conflictTaskItem.OriginalItem.SetMetadata("Private", "False");
                 }
                 else
                 {
-                    winningItemsByKey[itemKey] = conflictItem;
-                }
-            }
-
-            return RemoveConflicts(items, conflictsToRemove);
-        }
-
-        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2)
-        {
-            bool unused;
-            return HandleConflict(item1, item2, out unused);
-        }
-
-        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2, out bool equal)
-        {
-            equal = false;
-            var conflictMessage = $"Encountered conflict between {item1.DisplayName} and {item2.DisplayName}.";
-
-            var exists1 = item1.Exists;
-            var exists2 = item2.Exists;
-
-            if (!exists1 || !exists2)
-            {
-                var fileMessage = !exists1 ?
-                                    !exists2 ? 
-                                      "both files do" :
-                                      $"{item1.DisplayName} does" :
-                                  $"{item2.DisplayName} does";
-
-                Log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
-                return null;
-            }
-
-            var assemblyVersion1 = item1.AssemblyVersion;
-            var assemblyVersion2 = item2.AssemblyVersion;
-
-            // if only one is missing version stop: something is wrong when we have a conflict between assembly and non-assembly
-            if (assemblyVersion1 == null ^ assemblyVersion2 == null)
-            {
-                var nonAssembly = assemblyVersion1 == null ? item1.DisplayName : item2.DisplayName;
-                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
-                return null;
-            }
-
-            // only handle cases where assembly version is different, and not null (implicit here due to xor above)
-            if (assemblyVersion1 != assemblyVersion2)
-            {
-                if (assemblyVersion1 > assemblyVersion2)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
-                    return item1;
-                }
-
-                if (assemblyVersion2 > assemblyVersion1)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
-                    return item2;
-                }
-            }
-
-            var fileVersion1 = item1.FileVersion;
-            var fileVersion2 = item2.FileVersion;
-
-            // if only one is missing version
-            if (fileVersion1 == null ^ fileVersion2 == null)
-            {
-                var nonVersion = fileVersion1 == null ? item1.DisplayName : item2.DisplayName;
-                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
-                return null;
-            }
-
-            if (fileVersion1 != fileVersion2)
-            {
-                if (fileVersion1 > fileVersion2)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because file version {fileVersion1} is greater than {fileVersion2}.");
-                    return item1;
-                }
-
-                if (fileVersion2 > fileVersion1)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because file version {fileVersion2} is greater than {fileVersion1}.");
-                    return item2;
-                }
-            }
-
-            var packageRank1 = GetPackageRank(item1);
-            var packageRank2 = GetPackageRank(item2);
-
-            if (packageRank1 < packageRank2)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because package it comes from a package that is preferred.");
-                return item1;
-            }
-
-            if (packageRank2 < packageRank1)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is preferred.");
-                return item2;
-            }
-
-            Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
-            equal = true;
-            return null;
-        }
-
-        private bool HandleExternalConflict(ConflictItem item)
-        {
-            ConflictItem platformItem;
-
-            if (platformRuntimeByFileName.TryGetValue(item.FileName, out platformItem))
-            {
-                bool equal;
-                var winner = HandleConflict(item, platformItem, out equal);
-
-                if (winner == platformItem || equal)
-                {
-                    return true;
-                }
-                else if (winner == item)
-                {
-                    platformRuntimeByFileName.Remove(item.FileName);
-                }
-            }
-
-            return false;
-        }
-
-        private void LoadPlatform()
-        {
-            IEnumerable<ConflictItem> platformItems = Enumerable.Empty<ConflictItem>();
-
-            if (PlatformItems != null)
-            {
-                platformItems = platformItems.Concat(PlatformItems.Select(e => new ConflictItem(e, ConflictItemType.Platform)));
-            }
-
-            if (PlatformManifests != null)
-            {
-                platformItems = platformItems.Concat(PlatformManifests.SelectMany(manifestItem => LoadPlatformManifest(manifestItem.GetMetadata("FullPath"))));
-            }
-
-            foreach (var platformItem in platformItems)
-            {
-                ConflictItem existingItem;
-
-                if (!platformRuntimeByFileName.TryGetValue(platformItem.FileName, out existingItem) ||
-                    HandleConflict(existingItem, platformItem) == platformItem)
-                {
-                    // we only care about the winners for platform items
-                    // the losers are redundant since we only use this map
-                    // to determine if Reference/CopyLocal should be trimmed.
-                    platformRuntimeByFileName[platformItem.FileName] = platformItem;
-                }
-            }
-        }
-
-        private IEnumerable<ConflictItem> LoadPlatformManifest(string manifestPath)
-        {
-            if (manifestPath == null)
-            {
-                throw new ArgumentNullException(nameof(manifestPath));
-            }
-
-            if (!File.Exists(manifestPath))
-            {
-                Log.LogError($"Could not load {nameof(PlatformManifests)} from {manifestPath} because it did not exist");
-                yield break;
-            }
-
-            using (var manfiestStream = File.Open(manifestPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-            using (var manifestReader = new StreamReader(manfiestStream))
-            {
-                for (int lineNumber = 0; !manifestReader.EndOfStream; lineNumber++)
-                {
-                    var line = manifestReader.ReadLine().Trim();
-
-                    if (line.Length == 0 || line[0] == '#')
-                    {
-                        continue;
-                    }
-
-                    var lineParts = line.Split(s_manifestLineSeparator);
-
-                    if (lineParts.Length != 4)
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  Lines must have the format fileName|packageId|assemblyVersion|fileVersion");
-                        yield break;
-                    }
-
-                    var fileName = lineParts[0].Trim();
-                    var packageId = lineParts[1].Trim();
-                    var assemblyVersionString = lineParts[2].Trim();
-                    var fileVersionString = lineParts[3].Trim();
-
-                    Version assemblyVersion = null, fileVersion = null;
-
-                    if (assemblyVersionString.Length != 0 && !Version.TryParse(assemblyVersionString, out assemblyVersion))
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  AssemblyVersion {assemblyVersionString} was invalid.");
-                    }
-
-                    if (fileVersionString.Length != 0 && !Version.TryParse(fileVersionString, out fileVersion))
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  FileVersion {fileVersionString} was invalid.");
-                    }
-
-                    yield return new ConflictItem(fileName, packageId, assemblyVersion, fileVersion);
+                    copyLocalConflicts.Add(conflictTaskItem.OriginalItem);
                 }
             }
         }
@@ -444,6 +131,25 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             return result;
+        }
+
+        private class MSBuildLog : ILog
+        {
+            private TaskLoggingHelper logger;
+            public MSBuildLog(TaskLoggingHelper logger)
+            {
+                this.logger = logger;
+            }
+
+            public void LogError(string errorMessage)
+            {
+                logger.LogError(errorMessage);
+            }
+
+            public void LogMessage(string message)
+            {
+                logger.LogMessage(message);
+            }
         }
 
     }

--- a/netstandard/tools/IConflictItem.cs
+++ b/netstandard/tools/IConflictItem.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    interface IConflictItem
+    {
+        Version AssemblyVersion { get; }
+
+        bool Exists { get; }
+
+        string FileName { get; }
+
+        Version FileVersion { get; }
+
+        bool IsPlatform { get; }
+
+        string PackageId { get; }
+
+        string SourcePath { get; }
+
+        string DisplayName { get; }
+    }
+}

--- a/netstandard/tools/ILog.cs
+++ b/netstandard/tools/ILog.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    interface ILog
+    {
+        void LogMessage(string message);
+        void LogError(string errorMessage);
+    }
+}

--- a/netstandard/tools/ItemUtilities.cs
+++ b/netstandard/tools/ItemUtilities.cs
@@ -70,6 +70,13 @@ namespace Microsoft.DotNet.Build.Tasks
             return GetTargetPath(item);
         }
 
+        public static string GetReferenceTargetFileName(ITaskItem item)
+        {
+            var targetPath = GetReferenceTargetPath(item);
+
+            return targetPath != null ? Path.GetFileName(targetPath) : null;
+        }
+
         public static string GetSourcePath(ITaskItem item)
         {
             var sourcePath = item.GetMetadata("HintPath");

--- a/netstandard/tools/NETStandard.Tools.builds
+++ b/netstandard/tools/NETStandard.Tools.builds
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj" />
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj">
-      <TargetGroup>net45</TargetGroup>
+      <TargetGroup>net451</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -11,11 +11,16 @@
   <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
+    <Compile Include="ConflictResolver.cs" />
+    <Compile Include="ConflictPlatformItem.cs" />
+    <Compile Include="IConflictItem.cs" />
+    <Compile Include="ILog.cs" />
     <Compile Include="ItemUtilities.cs" />
-    <Compile Include="ConflictItem.cs" />
+    <Compile Include="ConflictTaskItem.cs" />
     <Compile Include="HandlePackageFileConflicts.cs" />
     <Compile Include="FileUtilities.cs" />
     <Compile Include="MSBuildUtilities.cs" />
+    <Compile Include="PackageRank.cs" />
     <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net45'">

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -4,12 +4,12 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net45'">.NETFramework,Version=v4.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net451'">.NETFramework,Version=v4.5.1</NuGetTargetMoniker>
     <CLSCompliant>false</CLSCompliant>
     <ProjectGuid>{65E58605-AE96-46C2-8C6C-F28A5EB9B565}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
-  <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'net451_Debug'" />
   <ItemGroup>
     <Compile Include="ConflictResolver.cs" />
     <Compile Include="ConflictPlatformItem.cs" />
@@ -18,16 +18,18 @@
     <Compile Include="ItemUtilities.cs" />
     <Compile Include="ConflictTaskItem.cs" />
     <Compile Include="HandlePackageFileConflicts.cs" />
+    <Compile Include="RemoveDepsFileConflicts.cs" />
     <Compile Include="FileUtilities.cs" />
     <Compile Include="MSBuildUtilities.cs" />
+    <Compile Include="NuGetUtilities.cs" />
     <Compile Include="PackageRank.cs" />
     <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net451'">
     <Compile Include="FileUtilities.netstandard.cs" />
     <PackageDestination Include="build" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net451'">
     <Compile Include="FileUtilities.net45.cs" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />

--- a/netstandard/tools/NuGetUtilities.cs
+++ b/netstandard/tools/NuGetUtilities.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class NuGetUtilities
+    {
+        /// <summary>
+        /// Gets PackageId from sourcePath.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static string GetPackageIdFromSourcePath(string sourcePath)
+        {
+            try
+            {
+                // this method is just a temporary heuristic until we get metadata added to items created by the .NETCore SDK
+                for(var dir = Directory.GetParent(sourcePath); dir != null; dir = dir.Parent)
+                {
+                    var nuspecs = dir.GetFiles("*.nuspec");
+
+                    if (nuspecs.Length > 0)
+                    {
+                        return Path.GetFileNameWithoutExtension(nuspecs[0].Name);
+                    }
+                }
+            }
+            catch (Exception)
+            { }
+
+            return null;
+        }
+    }
+}

--- a/netstandard/tools/PackageRank.cs
+++ b/netstandard/tools/PackageRank.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    class PackageRank
+    {
+        private Dictionary<string, int> packageRanks;
+
+        public PackageRank(string[] packageIds)
+        {
+            var numPackages = packageIds?.Length ?? 0;
+
+            // cache ranks for fast lookup
+            packageRanks = new Dictionary<string, int>(numPackages, StringComparer.OrdinalIgnoreCase);
+
+            for (int i = numPackages - 1; i >= 0; i--)
+            {
+                var preferredPackageId = packageIds[i].Trim();
+
+                if (preferredPackageId.Length != 0)
+                {
+                    // overwrite any duplicates, lowest rank will win.
+                    packageRanks[preferredPackageId] = i;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get's the rank of a package, lower packages are preferred
+        /// </summary>
+        /// <param name="packageId">id of package</param>
+        /// <returns>rank of package</returns>
+        public int GetPackageRank(string packageId)
+        {
+            int rank = int.MaxValue;
+
+            if (packageId != null)
+            {
+                packageRanks.TryGetValue(packageId, out rank);
+            }
+
+            return rank;
+        }
+    }
+}

--- a/netstandard/tools/ReferenceComparer.cs
+++ b/netstandard/tools/ReferenceComparer.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System;
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/netstandard/tools/RemoveDepsFileConflicts.cs
+++ b/netstandard/tools/RemoveDepsFileConflicts.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class RemoveDepsFileConflicts : Task
+    {
+        HashSet<string> conflictPackages;
+
+        [Required]
+        public string DepsFilePath { get; set; }
+
+        [Required]
+        public ITaskItem[] ConflictPackages { get; set; }
+
+        public override bool Execute()
+        {
+            conflictPackages = new HashSet<string>(ConflictPackages.Select(p => p.ItemSpec), StringComparer.OrdinalIgnoreCase);
+
+            DependencyContext sourceDeps;
+            using (var sourceStream = File.Open(DepsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            {
+                sourceDeps = new DependencyContextJsonReader().Read(sourceStream);
+            }
+
+            DependencyContext trimmedDeps = TrimConflicts(sourceDeps);
+
+            var writer = new DependencyContextWriter();
+            using (var fileStream = File.Create(DepsFilePath))
+            {
+                writer.Write(trimmedDeps, fileStream);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private DependencyContext TrimConflicts(DependencyContext sourceDeps)
+        {
+            return new DependencyContext(sourceDeps.Target,
+                                         sourceDeps.CompilationOptions,
+                                         TrimCompilationLibraries(sourceDeps.CompileLibraries),
+                                         TrimRuntimeLibraries(sourceDeps.RuntimeLibraries),
+                                         sourceDeps.RuntimeGraph);
+        }
+
+
+        // Array.Empty doesn't exist on net451
+        static readonly RuntimeAssetGroup[] s_emptyRuntimeAssetGroup = new RuntimeAssetGroup[0];
+        private IEnumerable<RuntimeLibrary> TrimRuntimeLibraries(IReadOnlyList<RuntimeLibrary> runtimeLibraries)
+        {
+            foreach(var runtimeLibrary in runtimeLibraries)
+            {
+                if (conflictPackages.Contains(runtimeLibrary.Name))
+                {
+                    yield return new RuntimeLibrary(runtimeLibrary.Type,
+                                              runtimeLibrary.Name,
+                                              runtimeLibrary.Version,
+                                              runtimeLibrary.Hash,
+                                              s_emptyRuntimeAssetGroup,
+                                              s_emptyRuntimeAssetGroup,
+                                              Enumerable.Empty<ResourceAssembly>(),
+                                              runtimeLibrary.Dependencies,
+                                              runtimeLibrary.Serviceable);
+                }
+                else
+                {
+                    yield return runtimeLibrary;
+                }
+            }
+        }
+
+        private IEnumerable<CompilationLibrary> TrimCompilationLibraries(IReadOnlyList<CompilationLibrary> compileLibraries)
+        {
+            foreach (var compileLibrary in compileLibraries)
+            {
+                if (conflictPackages.Contains(compileLibrary.Name))
+                {
+                    yield return new CompilationLibrary(compileLibrary.Type,
+                                              compileLibrary.Name,
+                                              compileLibrary.Version,
+                                              compileLibrary.Hash,
+                                              Enumerable.Empty<string>(),
+                                              compileLibrary.Dependencies,
+                                              compileLibrary.Serviceable);
+                }
+                else
+                {
+                    yield return compileLibrary;
+                }
+            }
+        }
+    }
+}

--- a/netstandard/tools/project.json
+++ b/netstandard/tools/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "NETStandard.Library": "1.6.0",
     "System.Reflection.Metadata": "1.3.0"
   },
@@ -19,9 +20,9 @@
       },
       "imports": [ "dnxcore50", "portable-net45+win8+wpa81" ]
     },
-    "net45": {
+    "net451": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.5.1": "1.0.1"
       }
     }
   }

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -18,6 +18,10 @@
       <PropertyGroup>
         <HandlePackageFileConflictsAfter>ResolvePackageDependenciesForBuild</HandlePackageFileConflictsAfter>
         <HandlePublishFileConflictsAfter>RunResolvePublishAssemblies</HandlePublishFileConflictsAfter>
+        <RemoveDepsFileConflictsAfter>GenerateBuildDependencyFile</RemoveDepsFileConflictsAfter>
+        <!-- If CopyLocalLockFileAssemblies is not true the host will run from packages,
+             but we still need to consider those package items for conflicts -->
+        <HandlePackageFileConflictsDependsOn Condition="'$(CopyLocalLockFileAssemblies)' != 'true'">_GetLockFileAssemblies</HandlePackageFileConflictsDependsOn>
       </PropertyGroup>
     </When>
     <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
@@ -53,15 +57,33 @@
     </ReferenceCopyLocalPaths>
   </ItemGroup>
 
+  <Target Name="_GetLockFileAssemblies"
+          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+                            _DefaultMicrosoftNETPlatformLibrary">
+    <!-- Essentially a copy of the SDKs RunResolvePublishAssemblies.
+         We need to find all the files that will be loaded from deps for conflict resolution.-->
+    <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
+                              AssetsFilePath="$(ProjectAssetsFile)"
+                              TargetFramework="$(TargetFrameworkMoniker)"
+                              RuntimeIdentifier="$(RuntimeIdentifier)"
+                              PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
+
+      <Output TaskParameter="AssembliesToPublish" ItemName="_LockFileAssemblies" />
+
+    </ResolvePublishAssemblies>
+  </Target>
+
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
-  <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
+  <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)" DependsOnTargets="$(HandlePackageFileConflictsDependsOn)">
     <HandlePackageFileConflicts References="@(Reference)"
                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                                PlatformItems="@(PackageConflictPlatformItems)"
+                                OtherRuntimeItems="@(_LockFileAssemblies)"
                                 PlatformManifests="@(PackageConflictPlatformManifests)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
+      <Output TaskParameter="ConflictPackages" ItemName="_ConflictPackages" />
     </HandlePackageFileConflicts>
 
     <!-- Replace Reference / ReferenceCopyLocalPaths with the filtered lists.
@@ -74,6 +96,19 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsWithoutConflicts)" />
     </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <_RemoveDepsFileConflictsSemaphore>$(IntermediateOutputPath)\RemoveDepsFileConflicts.semaphore</_RemoveDepsFileConflictsSemaphore>
+  </PropertyGroup>
+  <UsingTask TaskName="RemoveDepsFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
+  <Target Name="RemoveDepsFileConflicts" AfterTargets="$(RemoveDepsFileConflictsAfter)"
+          Inputs="$(ProjectDepsFilePath)" Outputs="$(_RemoveDepsFileConflictsSemaphore)">
+    <RemoveDepsFileConflicts DepsFilePath="$(ProjectDepsFilePath)" ConflictPackages="@(_ConflictPackages)" />
+
+    <Touch Files="$(_RemoveDepsFileConflictsSemaphore)" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
   </Target>
 
   <Target Name="HandlePublishFileConflicts" AfterTargets="$(HandlePublishFileConflictsAfter)">


### PR DESCRIPTION
/cc @weshaggard @eerhardt 

This adds a temporary implementation of deps file trimming.  I've also tried to refactor the logic into some reusable types that we could share with SDK.

I needed to copy the publish target to get the files out of the lock file.  I considered trying to derive everything from items that already existed but it was messy.

To do the trimming I've just assumed we'd trim the entire package.  In the production version in the SDK we should only trim conflicting files.