### PR TITLE
Trim Deps file

### DIFF
--- a/netstandard/tools/ConflictItem.cs
+++ b/netstandard/tools/ConflictItem.cs
@@ -12,9 +12,9 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         Reference,
         CopyLocal,
+        Runtime,
         Platform
     }
-
     // Wraps an ITask item and adds lazy evaluated properties used by Conflict resolution.
     internal class ConflictItem
     {
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (fileName == null)
                 {
-                    fileName = OriginalItem == null ? String.Empty : OriginalItem.GetMetadata("FileName") + OriginalItem.GetMetadata("Extension");
+                    fileName = OriginalItem == null ? String.Empty : OriginalItem.GetMetadata(MetadataNames.FileName) + OriginalItem.GetMetadata(MetadataNames.Extension);
                 }
                 return fileName;
             }
@@ -142,7 +142,12 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (packageId == null)
                 {
-                    packageId = OriginalItem?.GetMetadata("NuGetPackageId") ?? String.Empty;
+                    packageId = OriginalItem?.GetMetadata(MetadataNames.NuGetPackageId) ?? String.Empty;
+
+                    if (packageId.Length == 0)
+                    {
+                        packageId = NuGetUtilities.GetPackageIdFromSourcePath(SourcePath) ?? String.Empty;
+                    }
                 }
 
                 return packageId.Length == 0 ? null : packageId;

--- a/netstandard/tools/ConflictResolver.cs
+++ b/netstandard/tools/ConflictResolver.cs
@@ -1,0 +1,184 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    class ConflictResolver
+    {
+        private Dictionary<string, ConflictItem> winningItemsByKey = new Dictionary<string, ConflictItem>();
+        private ILog log;
+        private PackageRank packageRank;
+
+        public ConflictResolver(PackageRank packageRank, ILog log)
+        {
+            this.log = log;
+            this.packageRank = packageRank;
+        }
+
+        public void ResolveConflicts(IEnumerable<ConflictItem> conflictItems, Func<ConflictItem, string> getItemKey, Action<ConflictItem> foundConflict, bool commitWinner = true)
+        {
+            if (conflictItems == null)
+            {
+                return;
+            }
+
+            foreach (var conflictItem in conflictItems)
+            {
+                var itemKey = getItemKey(conflictItem);
+
+                if (String.IsNullOrEmpty(itemKey))
+                {
+                    continue;
+                }
+
+                ConflictItem existingItem;
+
+                if (winningItemsByKey.TryGetValue(itemKey, out existingItem))
+                {
+                    // a conflict was found, determine the winner.
+                    var winner = ResolveConflict(existingItem, conflictItem);
+
+                    if (winner == null)
+                    {
+                        // no winner, skip it.
+                        // don't add to conflict list and just use the existing item for future conflicts.
+                        continue;
+                    }
+
+                    ConflictItem loser = conflictItem;
+                    if (!ReferenceEquals(winner, existingItem))
+                    {
+                        // replace existing item
+                        if (commitWinner)
+                        {
+                            winningItemsByKey[itemKey] = conflictItem;
+                        }
+                        else
+                        {
+                            winningItemsByKey.Remove(itemKey);
+                        }
+                        loser = existingItem;
+
+                    }
+
+                    foundConflict(loser);
+                }
+                else if (commitWinner)
+                {
+                    winningItemsByKey[itemKey] = conflictItem;
+                }
+            }
+        }
+
+        private ConflictItem ResolveConflict(ConflictItem item1, ConflictItem item2)
+        {
+            var conflictMessage = $"Encountered conflict between {item1.DisplayName} and {item2.DisplayName}.";
+
+            var exists1 = item1.Exists;
+            var exists2 = item2.Exists;
+
+            if (!exists1 || !exists2)
+            {
+                var fileMessage = !exists1 ?
+                                    !exists2 ?
+                                      "both files do" :
+                                      $"{item1.DisplayName} does" :
+                                  $"{item2.DisplayName} does";
+
+                log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
+                return null;
+            }
+
+            var assemblyVersion1 = item1.AssemblyVersion;
+            var assemblyVersion2 = item2.AssemblyVersion;
+
+            // if only one is missing version stop: something is wrong when we have a conflict between assembly and non-assembly
+            if (assemblyVersion1 == null ^ assemblyVersion2 == null)
+            {
+                var nonAssembly = assemblyVersion1 == null ? item1.DisplayName : item2.DisplayName;
+                log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
+                return null;
+            }
+
+            // only handle cases where assembly version is different, and not null (implicit here due to xor above)
+            if (assemblyVersion1 != assemblyVersion2)
+            {
+                if (assemblyVersion1 > assemblyVersion2)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
+                    return item1;
+                }
+
+                if (assemblyVersion2 > assemblyVersion1)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
+                    return item2;
+                }
+            }
+
+            var fileVersion1 = item1.FileVersion;
+            var fileVersion2 = item2.FileVersion;
+
+            // if only one is missing version
+            if (fileVersion1 == null ^ fileVersion2 == null)
+            {
+                var nonVersion = fileVersion1 == null ? item1.DisplayName : item2.DisplayName;
+                log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
+                return null;
+            }
+
+            if (fileVersion1 != fileVersion2)
+            {
+                if (fileVersion1 > fileVersion2)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because file version {fileVersion1} is greater than {fileVersion2}.");
+                    return item1;
+                }
+
+                if (fileVersion2 > fileVersion1)
+                {
+                    log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because file version {fileVersion2} is greater than {fileVersion1}.");
+                    return item2;
+                }
+            }
+
+            var packageRank1 = packageRank.GetPackageRank(item1.PackageId);
+            var packageRank2 = packageRank.GetPackageRank(item2.PackageId);
+
+            if (packageRank1 < packageRank2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because package it comes from a package that is preferred.");
+                return item1;
+            }
+
+            if (packageRank2 < packageRank1)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is preferred.");
+                return item2;
+            }
+
+            var isPlatform1 = item1.ItemType == ConflictItemType.Platform;
+            var isPlatform2 = item2.ItemType == ConflictItemType.Platform;
+
+            if (isPlatform1 && !isPlatform2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because it is a platform item.");
+                return item1;
+            }
+
+            if (!isPlatform1 && isPlatform2)
+            {
+                log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because it is a platform item.");
+                return item1;
+            }
+
+            log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
+            return null;
+        }
+    }
+}

--- a/netstandard/tools/FileUtilities.netstandard.cs
+++ b/netstandard/tools/FileUtilities.netstandard.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Build.Utilities;
 using System;
 using System.IO;
 using System.Reflection.Metadata;

--- a/netstandard/tools/HandlePackageFileConflicts.cs
+++ b/netstandard/tools/HandlePackageFileConflicts.cs
@@ -6,23 +6,21 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class HandlePackageFileConflicts : Task
     {
-        static readonly char[] s_manifestLineSeparator = new[] { '|' };
-        private Dictionary<string, int> packageRanks = null;
-        private Dictionary<string, ConflictItem> platformRuntimeByFileName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
-        private Dictionary<string, ConflictItem> runtimeItemsByTargetPath = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
+        HashSet<ITaskItem> referenceConflicts = new HashSet<ITaskItem>();
+        HashSet<ITaskItem> copyLocalConflicts = new HashSet<ITaskItem>();
+        HashSet<ConflictItem> allConflicts = new HashSet<ConflictItem>();
 
         public ITaskItem[] References { get; set; }
 
         public ITaskItem[] ReferenceCopyLocalPaths { get; set; }
 
-        public ITaskItem[] PlatformItems { get; set; }
+        public ITaskItem[] OtherRuntimeItems { get; set; }
 
         public ITaskItem[] PlatformManifests { get; set; }
 
@@ -37,382 +35,119 @@ namespace Microsoft.DotNet.Build.Tasks
         [Output]
         public ITaskItem[] ReferenceCopyLocalPathsWithoutConflicts { get; set; }
 
+        [Output]
+        public ITaskItem[] Conflicts { get; set; }
+
         public override bool Execute()
         {
-            // remove References that will conflict at compile
-            var referencesWithoutConflicts = HandleReferenceConflicts(References);
+            var log = new MSBuildLog(Log);
+            var packageRanks = new PackageRank(PreferredPackages);
 
-            LoadPlatform();
+            // resolve conflicts at compile time
+            var referenceItems = GetConflictTaskItems(References, ConflictItemType.Reference).ToArray();
 
-            // remove References that will conflict in output or with platform items.
-            referencesWithoutConflicts = HandleRuntimeConflicts(referencesWithoutConflicts, ConflictItemType.Reference, ItemUtilities.GetReferenceTargetPath);
+            var compileConflictScope = new ConflictResolver(packageRanks, log);
 
-            // remove ReferenceCopyLocalPaths that will conflict in output or with platform items.
-            var referenceCopyLocalPathsWithoutConflicts = HandleRuntimeConflicts(ReferenceCopyLocalPaths, ConflictItemType.CopyLocal, ItemUtilities.GetTargetPath);
+            compileConflictScope.ResolveConflicts(referenceItems,
+                ci => ItemUtilities.GetReferenceFileName(ci.OriginalItem),
+                HandleCompileConflict);
 
-            ReferencesWithoutConflicts = referencesWithoutConflicts;
-            ReferenceCopyLocalPathsWithoutConflicts = referenceCopyLocalPathsWithoutConflicts;
+            // resolve conflicts that class in output
+            var runtimeConflictScope = new ConflictResolver(packageRanks, log);
+
+            runtimeConflictScope.ResolveConflicts(referenceItems,
+                ci => ItemUtilities.GetReferenceTargetPath(ci.OriginalItem),
+                HandleRuntimeConflict);
+
+            var copyLocalItems = GetConflictTaskItems(ReferenceCopyLocalPaths, ConflictItemType.CopyLocal).ToArray();
+
+            runtimeConflictScope.ResolveConflicts(copyLocalItems,
+                ci => ItemUtilities.GetTargetPath(ci.OriginalItem),
+                HandleRuntimeConflict);
+
+            var otherRuntimeItems = GetConflictTaskItems(OtherRuntimeItems, ConflictItemType.Runtime).ToArray();
+
+            runtimeConflictScope.ResolveConflicts(otherRuntimeItems,
+                ci => ItemUtilities.GetTargetPath(ci.OriginalItem),
+                HandleRuntimeConflict);
+
+
+            // resolve conflicts with platform (eg: shared framework) items
+            // we only commit the platform items since its not a conflict if other items share the same filename.
+            var platformConflictScope = new ConflictResolver(packageRanks, log);
+            var platformItems = PlatformManifests?.SelectMany(pm => PlatformManifestReader.LoadConflictItems(pm.ItemSpec, log)) ?? Enumerable.Empty<ConflictItem>();
+
+            platformConflictScope.ResolveConflicts(platformItems, pi => pi.FileName, pi => { });
+            platformConflictScope.ResolveConflicts(referenceItems.Where(ri => !referenceConflicts.Contains(ri.OriginalItem)),
+                                                   ri => ItemUtilities.GetReferenceTargetFileName(ri.OriginalItem),
+                                                   HandleRuntimeConflict,
+                                                   commitWinner:false);
+            platformConflictScope.ResolveConflicts(copyLocalItems.Where(ci => !copyLocalConflicts.Contains(ci.OriginalItem)),
+                                                   ri => ri.FileName,
+                                                   HandleRuntimeConflict,
+                                                   commitWinner: false);
+            platformConflictScope.ResolveConflicts(otherRuntimeItems,
+                                                   ri => ri.FileName,
+                                                   HandleRuntimeConflict,
+                                                   commitWinner: false);
+
+            ReferencesWithoutConflicts = RemoveConflicts(References, referenceConflicts);
+            ReferenceCopyLocalPathsWithoutConflicts = RemoveConflicts(ReferenceCopyLocalPaths, copyLocalConflicts);
+            Conflicts = CreateConflictTaskItems(allConflicts);
 
             return !Log.HasLoggedErrors;
         }
 
-        private void EnsurePackageRanks()
+        private ITaskItem[] CreateConflictTaskItems(ICollection<ConflictItem> conflicts)
         {
-            if (packageRanks == null)
+            var conflictItems = new ITaskItem[conflicts.Count];
+
+            int i = 0;
+            foreach(var conflict in conflicts)
             {
-                var numPreferredPackages = PreferredPackages?.Length ?? 0;
-
-                // cache ranks for fast lookup
-                packageRanks = new Dictionary<string, int>(numPreferredPackages, StringComparer.OrdinalIgnoreCase);
-
-                for (int i = numPreferredPackages - 1; i >= 0 ; i--)
-                {
-                    var preferredPackageId = PreferredPackages[i].Trim();
-
-                    if (preferredPackageId.Length != 0)
-                    {
-                        // overwrite any duplicates, lowest rank will win.
-                        packageRanks[preferredPackageId] = i;
-                    }
-                }
+                conflictItems[i++] = CreateConflictTaskItem(conflict);
             }
+
+            return conflictItems;
         }
 
-        private int GetPackageRank(ConflictItem item)
+        private ITaskItem CreateConflictTaskItem(ConflictItem conflict)
         {
-            int rank = int.MaxValue;
+            var item = new TaskItem(conflict.SourcePath);
 
-            if (item.PackageId != null && PreferredPackages != null)
+            if (conflict.PackageId != null)
             {
-                EnsurePackageRanks();
-
-                packageRanks.TryGetValue(item.PackageId, out rank);
+                item.SetMetadata(nameof(ConflictItemType), conflict.ItemType.ToString());
             }
 
-            return rank;
+            return item;
         }
 
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleReferenceConflicts(ITaskItem[] items)
+        private IEnumerable<ConflictItem> GetConflictTaskItems(ITaskItem[] items, ConflictItemType itemType)
         {
-            Dictionary<string, ConflictItem> referenceByName = new Dictionary<string, ConflictItem>(StringComparer.OrdinalIgnoreCase);
-
-            return HandleConflicts(items, ConflictItemType.Reference, ItemUtilities.GetReferenceFileName, referenceByName);
+            return (items != null) ? items.Select(i => new ConflictItem(i, itemType)) : Enumerable.Empty<ConflictItem>();
         }
 
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
-        /// <param name="getItemKey">Delegate to calculate key for an item</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleRuntimeConflicts(ITaskItem[] items, ConflictItemType itemType, Func<ITaskItem, string> getItemKey)
+        private void HandleCompileConflict(ConflictItem conflictItem)
         {
-            return HandleConflicts(items, itemType, getItemKey, runtimeItemsByTargetPath, checkPlatform:true);
+            if (conflictItem.ItemType == ConflictItemType.Reference)
+            {
+                referenceConflicts.Add(conflictItem.OriginalItem);
+            }
+            allConflicts.Add(conflictItem);
         }
 
-        /// <summary>
-        /// Examines items for conflicting keys and chooses the best item.
-        /// </summary>
-        /// <param name="items">Items from which to remove conflicts</param>
-        /// <param name="itemType">Type of items represented by <paramref name="items"/></param>
-        /// <param name="getItemKey">Delegate to calculate key for an item</param>
-        /// <param name="winningItemsByKey">Dictionary of items by key without conflicts</param>
-        /// <param name="checkPlatform">If items should be checked for conflicts against platform items</param>
-        /// <returns>Items without conflicts</returns>
-        private ITaskItem[] HandleConflicts(ITaskItem[] items,
-                                            ConflictItemType itemType,
-                                            Func<ITaskItem, string> getItemKey,
-                                            Dictionary<string, ConflictItem> winningItemsByKey,
-                                            bool checkPlatform = false)
+        private void HandleRuntimeConflict(ConflictItem conflictItem)
         {
-            if (items == null)
+            if (conflictItem.ItemType == ConflictItemType.Reference)
             {
-                return items;
+                conflictItem.OriginalItem.SetMetadata(MetadataNames.Private, "False");
             }
-
-            // ensure we use reference equality and not any overridden equality operators on items
-            var conflictsToRemove = new HashSet<ITaskItem>(ReferenceComparer<ITaskItem>.Instance);
-
-            foreach (var item in items)
+            else if (conflictItem.ItemType == ConflictItemType.CopyLocal)
             {
-                var itemKey = getItemKey(item);
-
-                if (String.IsNullOrEmpty(itemKey))
-                {
-                    continue;
-                }
-
-                ConflictItem existingItem, conflictItem = new ConflictItem(item, itemType);
-
-                if (checkPlatform && HandleExternalConflict(conflictItem))
-                {
-                    conflictsToRemove.Add(item);
-                    continue;
-                }
-
-                if (winningItemsByKey.TryGetValue(itemKey, out existingItem))
-                {
-                    // a conflict was found, determine the winner.
-                    var winner = HandleConflict(existingItem, conflictItem);
-
-                    if (winner == null)
-                    {
-                        // no winner, skip it.
-                        // don't add to conflict list and just use the existing item for future conflicts.
-                        continue;
-                    }
-
-                    if (!ReferenceEquals(winner, existingItem))
-                    {
-                        // replace existing item
-                        winningItemsByKey[itemKey] = conflictItem;
-
-                        if (existingItem.ItemType == itemType)
-                        {
-                            if (existingItem.OriginalItem != null)
-                            {
-                                // same type as we're currently processing remove it from item list
-                                conflictsToRemove.Add(existingItem.OriginalItem);
-                            }
-                        }
-                        else if (existingItem.ItemType == ConflictItemType.Reference)
-                        {
-                            if (existingItem.OriginalItem != null)
-                            {
-                                // Existing item is a Reference and winning item is CopyLocal or External
-                                // make the Reference not private, so that it will not copy-local
-                                existingItem.OriginalItem.SetMetadata("Private", "False");
-                            }
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException($"Internal error. Cannot remove item from {existingItem.ItemType} when processing {itemType}.");
-                        }
-                    }
-                    else
-                    {
-                        // no need to replace item, just add new item to conflict list.
-                        conflictsToRemove.Add(item);
-                    }
-                }
-                else
-                {
-                    winningItemsByKey[itemKey] = conflictItem;
-                }
+                copyLocalConflicts.Add(conflictItem.OriginalItem);
             }
-
-            return RemoveConflicts(items, conflictsToRemove);
-        }
-
-        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2)
-        {
-            bool unused;
-            return HandleConflict(item1, item2, out unused);
-        }
-
-        private ConflictItem HandleConflict(ConflictItem item1, ConflictItem item2, out bool equal)
-        {
-            equal = false;
-            var conflictMessage = $"Encountered conflict between {item1.DisplayName} and {item2.DisplayName}.";
-
-            var exists1 = item1.Exists;
-            var exists2 = item2.Exists;
-
-            if (!exists1 || !exists2)
-            {
-                var fileMessage = !exists1 ?
-                                    !exists2 ? 
-                                      "both files do" :
-                                      $"{item1.DisplayName} does" :
-                                  $"{item2.DisplayName} does";
-
-                Log.LogMessage($"{conflictMessage}.  Could not determine winner because {fileMessage} not exist.");
-                return null;
-            }
-
-            var assemblyVersion1 = item1.AssemblyVersion;
-            var assemblyVersion2 = item2.AssemblyVersion;
-
-            // if only one is missing version stop: something is wrong when we have a conflict between assembly and non-assembly
-            if (assemblyVersion1 == null ^ assemblyVersion2 == null)
-            {
-                var nonAssembly = assemblyVersion1 == null ? item1.DisplayName : item2.DisplayName;
-                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonAssembly} is not an assembly.");
-                return null;
-            }
-
-            // only handle cases where assembly version is different, and not null (implicit here due to xor above)
-            if (assemblyVersion1 != assemblyVersion2)
-            {
-                if (assemblyVersion1 > assemblyVersion2)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because AssemblyVersion {assemblyVersion1} is greater than {assemblyVersion2}.");
-                    return item1;
-                }
-
-                if (assemblyVersion2 > assemblyVersion1)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because AssemblyVersion {assemblyVersion2} is greater than {assemblyVersion1}.");
-                    return item2;
-                }
-            }
-
-            var fileVersion1 = item1.FileVersion;
-            var fileVersion2 = item2.FileVersion;
-
-            // if only one is missing version
-            if (fileVersion1 == null ^ fileVersion2 == null)
-            {
-                var nonVersion = fileVersion1 == null ? item1.DisplayName : item2.DisplayName;
-                Log.LogMessage($"{conflictMessage}. Could not determine a winner because {nonVersion} has no file version.");
-                return null;
-            }
-
-            if (fileVersion1 != fileVersion2)
-            {
-                if (fileVersion1 > fileVersion2)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because file version {fileVersion1} is greater than {fileVersion2}.");
-                    return item1;
-                }
-
-                if (fileVersion2 > fileVersion1)
-                {
-                    Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because file version {fileVersion2} is greater than {fileVersion1}.");
-                    return item2;
-                }
-            }
-
-            var packageRank1 = GetPackageRank(item1);
-            var packageRank2 = GetPackageRank(item2);
-
-            if (packageRank1 < packageRank2)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item1.DisplayName} because package it comes from a package that is preferred.");
-                return item1;
-            }
-
-            if (packageRank2 < packageRank1)
-            {
-                Log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is preferred.");
-                return item2;
-            }
-
-            Log.LogMessage($"{conflictMessage}.  Could not determine winner due to equal file and assembly versions.");
-            equal = true;
-            return null;
-        }
-
-        private bool HandleExternalConflict(ConflictItem item)
-        {
-            ConflictItem platformItem;
-
-            if (platformRuntimeByFileName.TryGetValue(item.FileName, out platformItem))
-            {
-                bool equal;
-                var winner = HandleConflict(item, platformItem, out equal);
-
-                if (winner == platformItem || equal)
-                {
-                    return true;
-                }
-                else if (winner == item)
-                {
-                    platformRuntimeByFileName.Remove(item.FileName);
-                }
-            }
-
-            return false;
-        }
-
-        private void LoadPlatform()
-        {
-            IEnumerable<ConflictItem> platformItems = Enumerable.Empty<ConflictItem>();
-
-            if (PlatformItems != null)
-            {
-                platformItems = platformItems.Concat(PlatformItems.Select(e => new ConflictItem(e, ConflictItemType.Platform)));
-            }
-
-            if (PlatformManifests != null)
-            {
-                platformItems = platformItems.Concat(PlatformManifests.SelectMany(manifestItem => LoadPlatformManifest(manifestItem.GetMetadata("FullPath"))));
-            }
-
-            foreach (var platformItem in platformItems)
-            {
-                ConflictItem existingItem;
-
-                if (!platformRuntimeByFileName.TryGetValue(platformItem.FileName, out existingItem) ||
-                    HandleConflict(existingItem, platformItem) == platformItem)
-                {
-                    // we only care about the winners for platform items
-                    // the losers are redundant since we only use this map
-                    // to determine if Reference/CopyLocal should be trimmed.
-                    platformRuntimeByFileName[platformItem.FileName] = platformItem;
-                }
-            }
-        }
-
-        private IEnumerable<ConflictItem> LoadPlatformManifest(string manifestPath)
-        {
-            if (manifestPath == null)
-            {
-                throw new ArgumentNullException(nameof(manifestPath));
-            }
-
-            if (!File.Exists(manifestPath))
-            {
-                Log.LogError($"Could not load {nameof(PlatformManifests)} from {manifestPath} because it did not exist");
-                yield break;
-            }
-
-            using (var manfiestStream = File.Open(manifestPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-            using (var manifestReader = new StreamReader(manfiestStream))
-            {
-                for (int lineNumber = 0; !manifestReader.EndOfStream; lineNumber++)
-                {
-                    var line = manifestReader.ReadLine().Trim();
-
-                    if (line.Length == 0 || line[0] == '#')
-                    {
-                        continue;
-                    }
-
-                    var lineParts = line.Split(s_manifestLineSeparator);
-
-                    if (lineParts.Length != 4)
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  Lines must have the format fileName|packageId|assemblyVersion|fileVersion");
-                        yield break;
-                    }
-
-                    var fileName = lineParts[0].Trim();
-                    var packageId = lineParts[1].Trim();
-                    var assemblyVersionString = lineParts[2].Trim();
-                    var fileVersionString = lineParts[3].Trim();
-
-                    Version assemblyVersion = null, fileVersion = null;
-
-                    if (assemblyVersionString.Length != 0 && !Version.TryParse(assemblyVersionString, out assemblyVersion))
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  AssemblyVersion {assemblyVersionString} was invalid.");
-                    }
-
-                    if (fileVersionString.Length != 0 && !Version.TryParse(fileVersionString, out fileVersion))
-                    {
-                        Log.LogError($"Error parsing {nameof(PlatformManifests)} from {manifestPath} line {lineNumber}.  FileVersion {fileVersionString} was invalid.");
-                    }
-
-                    yield return new ConflictItem(fileName, packageId, assemblyVersion, fileVersion);
-                }
-            }
+            allConflicts.Add(conflictItem);
         }
 
         /// <summary>
@@ -444,6 +179,25 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             return result;
+        }
+
+        private class MSBuildLog : ILog
+        {
+            private TaskLoggingHelper logger;
+            public MSBuildLog(TaskLoggingHelper logger)
+            {
+                this.logger = logger;
+            }
+
+            public void LogError(string errorMessage)
+            {
+                logger.LogError(errorMessage);
+            }
+
+            public void LogMessage(string message)
+            {
+                logger.LogMessage(message);
+            }
         }
 
     }

--- a/netstandard/tools/ILog.cs
+++ b/netstandard/tools/ILog.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    interface ILog
+    {
+        void LogMessage(string message);
+        void LogError(string errorMessage);
+    }
+}

--- a/netstandard/tools/ItemUtilities.cs
+++ b/netstandard/tools/ItemUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <returns></returns>
         public static string GetReferenceFileName(ITaskItem item)
         {
-            var aliases = item.GetMetadata("Aliases");
+            var aliases = item.GetMetadata(MetadataNames.Aliases);
 
             if (!String.IsNullOrEmpty(aliases))
             {
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Build.Tasks
             // We're only dealing with primary file references.  For these RAR will 
             // copy local if Private is true or unset.
 
-            var isPrivate = MSBuildUtilities.ConvertStringToBool(item.GetMetadata("Private"), defaultValue: true);
+            var isPrivate = MSBuildUtilities.ConvertStringToBool(item.GetMetadata(MetadataNames.Private), defaultValue: true);
 
             if (!isPrivate)
             {
@@ -70,9 +70,16 @@ namespace Microsoft.DotNet.Build.Tasks
             return GetTargetPath(item);
         }
 
+        public static string GetReferenceTargetFileName(ITaskItem item)
+        {
+            var targetPath = GetReferenceTargetPath(item);
+
+            return targetPath != null ? Path.GetFileName(targetPath) : null;
+        }
+
         public static string GetSourcePath(ITaskItem item)
         {
-            var sourcePath = item.GetMetadata("HintPath");
+            var sourcePath = item.GetMetadata(MetadataNames.HintPath);
 
             if (String.IsNullOrWhiteSpace(sourcePath))
             {
@@ -85,7 +92,7 @@ namespace Microsoft.DotNet.Build.Tasks
             return sourcePath;
         }
 
-        static readonly string[] s_targetPathMetadata = new[] { "TargetPath", "DestinationSubPath", "Path" };
+        static readonly string[] s_targetPathMetadata = new[] { MetadataNames.TargetPath, MetadataNames.DestinationSubPath, MetadataNames.Path };
         public static string GetTargetPath(ITaskItem item)
         {
             // first use TargetPath, DestinationSubPath, then Path, then fallback to filename+extension alone

--- a/netstandard/tools/MetadataNames.cs
+++ b/netstandard/tools/MetadataNames.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Build.Tasks
+
+{
+    static class MetadataNames
+    {
+        public const string Aliases = "Aliases";
+        public const string DestinationSubPath = "DestinationSubPath";
+        public const string Extension = "Extension";
+        public const string FileName = "FileName";
+        public const string HintPath = "HintPath";
+        public const string NuGetPackageId = "NuGetPackageId";
+        public const string Path = "Path";
+        public const string Private = "Private";
+        public const string TargetPath = "TargetPath";
+    }
+}

--- a/netstandard/tools/NETStandard.Tools.builds
+++ b/netstandard/tools/NETStandard.Tools.builds
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj" />
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj">
-      <TargetGroup>net45</TargetGroup>
+      <TargetGroup>net451</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/netstandard/tools/NETStandard.Tools.csproj
+++ b/netstandard/tools/NETStandard.Tools.csproj
@@ -4,25 +4,32 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net45'">.NETFramework,Version=v4.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net451'">.NETFramework,Version=v4.5.1</NuGetTargetMoniker>
     <CLSCompliant>false</CLSCompliant>
     <ProjectGuid>{65E58605-AE96-46C2-8C6C-F28A5EB9B565}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
-  <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'net451_Debug'" />
   <ItemGroup>
+    <Compile Include="ConflictResolver.cs" />
+    <Compile Include="MetadataNames.cs" />
+    <Compile Include="PlatformManifestReader.cs" />
+    <Compile Include="ILog.cs" />
     <Compile Include="ItemUtilities.cs" />
     <Compile Include="ConflictItem.cs" />
     <Compile Include="HandlePackageFileConflicts.cs" />
+    <Compile Include="RemoveDepsFileConflicts.cs" />
     <Compile Include="FileUtilities.cs" />
     <Compile Include="MSBuildUtilities.cs" />
+    <Compile Include="NuGetUtilities.cs" />
+    <Compile Include="PackageRank.cs" />
     <Compile Include="ReferenceComparer.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net451'">
     <Compile Include="FileUtilities.netstandard.cs" />
     <PackageDestination Include="build" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net451'">
     <Compile Include="FileUtilities.net45.cs" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />

--- a/netstandard/tools/NuGetUtilities.cs
+++ b/netstandard/tools/NuGetUtilities.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class NuGetUtilities
+    {
+        /// <summary>
+        /// Gets PackageId from sourcePath.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static string GetPackageIdFromSourcePath(string sourcePath)
+        {
+            string packageId, unused;
+            GetPackageParts(sourcePath, out packageId, out unused);
+            return packageId;
+        }
+
+        /// <summary>
+        /// Gets PackageId and package subpath from source path
+        /// </summary>
+        /// <param name="fullPath">full path to package file</param>
+        /// <param name="packageId">package ID</param>
+        /// <param name="packageSubPath">subpath of asset within package</param>
+        public static void GetPackageParts(string fullPath, out string packageId, out string packageSubPath)
+        {
+            packageId = null;
+            packageSubPath = null;
+            try
+            {
+                // this method is just a temporary heuristic until we get metadata added to items created by the .NETCore SDK
+                for (var dir = Directory.GetParent(fullPath); dir != null; dir = dir.Parent)
+                {
+                    var nuspecs = dir.GetFiles("*.nuspec");
+
+                    if (nuspecs.Length > 0)
+                    {
+                        packageId = Path.GetFileNameWithoutExtension(nuspecs[0].Name);
+                        packageSubPath = fullPath.Substring(dir.FullName.Length + 1).Replace('\\', '/');
+                        break;
+                    }
+                }
+            }
+            catch (Exception)
+            { }
+
+            return;
+
+        }
+    }
+}

--- a/netstandard/tools/PackageRank.cs
+++ b/netstandard/tools/PackageRank.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    class PackageRank
+    {
+        private Dictionary<string, int> packageRanks;
+
+        public PackageRank(string[] packageIds)
+        {
+            var numPackages = packageIds?.Length ?? 0;
+
+            // cache ranks for fast lookup
+            packageRanks = new Dictionary<string, int>(numPackages, StringComparer.OrdinalIgnoreCase);
+
+            for (int i = numPackages - 1; i >= 0; i--)
+            {
+                var preferredPackageId = packageIds[i].Trim();
+
+                if (preferredPackageId.Length != 0)
+                {
+                    // overwrite any duplicates, lowest rank will win.
+                    packageRanks[preferredPackageId] = i;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get's the rank of a package, lower packages are preferred
+        /// </summary>
+        /// <param name="packageId">id of package</param>
+        /// <returns>rank of package</returns>
+        public int GetPackageRank(string packageId)
+        {
+            int rank = int.MaxValue;
+
+            if (packageId != null)
+            {
+                packageRanks.TryGetValue(packageId, out rank);
+            }
+
+            return rank;
+        }
+    }
+}

--- a/netstandard/tools/PlatformManifestReader.cs
+++ b/netstandard/tools/PlatformManifestReader.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static class PlatformManifestReader
+    {
+        static readonly char[] s_manifestLineSeparator = new[] { '|' };
+        public static IEnumerable<ConflictItem> LoadConflictItems(string manifestPath, ILog log)
+        {
+            if (manifestPath == null)
+            {
+                throw new ArgumentNullException(nameof(manifestPath));
+            }
+
+            if (!File.Exists(manifestPath))
+            {
+                log.LogError($"Could not load PlatformManifest from {manifestPath} because it did not exist");
+                yield break;
+            }
+
+            using (var manfiestStream = File.Open(manifestPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            using (var manifestReader = new StreamReader(manfiestStream))
+            {
+                for (int lineNumber = 0; !manifestReader.EndOfStream; lineNumber++)
+                {
+                    var line = manifestReader.ReadLine().Trim();
+
+                    if (line.Length == 0 || line[0] == '#')
+                    {
+                        continue;
+                    }
+
+                    var lineParts = line.Split(s_manifestLineSeparator);
+
+                    if (lineParts.Length != 4)
+                    {
+                        log.LogError($"Error parsing PlatformManifest from {manifestPath} line {lineNumber}.  Lines must have the format fileName|packageId|assemblyVersion|fileVersion");
+                        yield break;
+                    }
+
+                    var fileName = lineParts[0].Trim();
+                    var packageId = lineParts[1].Trim();
+                    var assemblyVersionString = lineParts[2].Trim();
+                    var fileVersionString = lineParts[3].Trim();
+
+                    Version assemblyVersion = null, fileVersion = null;
+
+                    if (assemblyVersionString.Length != 0 && !Version.TryParse(assemblyVersionString, out assemblyVersion))
+                    {
+                        log.LogError($"Error parsing PlatformManfiest from {manifestPath} line {lineNumber}.  AssemblyVersion {assemblyVersionString} was invalid.");
+                    }
+
+                    if (fileVersionString.Length != 0 && !Version.TryParse(fileVersionString, out fileVersion))
+                    {
+                        log.LogError($"Error parsing PlatformManifest from {manifestPath} line {lineNumber}.  FileVersion {fileVersionString} was invalid.");
+                    }
+
+                    yield return new ConflictItem(fileName, packageId, assemblyVersion, fileVersion);
+                }
+            }
+        }
+    }
+}

--- a/netstandard/tools/ReferenceComparer.cs
+++ b/netstandard/tools/ReferenceComparer.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System;
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/netstandard/tools/RemoveDepsFileConflicts.cs
+++ b/netstandard/tools/RemoveDepsFileConflicts.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class RemoveDepsFileConflicts : Task
+    {
+        Dictionary<string, HashSet<string>> compileConflicts = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, HashSet<string>> runtimeConflicts = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        [Required]
+        public string DepsFilePath { get; set; }
+
+        [Required]
+        public ITaskItem[] Conflicts { get; set; }
+
+        public override bool Execute()
+        {
+            LoadConflicts();
+
+            DependencyContext sourceDeps;
+            using (var sourceStream = File.Open(DepsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            {
+                sourceDeps = new DependencyContextJsonReader().Read(sourceStream);
+            }
+
+            DependencyContext trimmedDeps = TrimConflicts(sourceDeps);
+
+            var writer = new DependencyContextWriter();
+            using (var fileStream = File.Create(DepsFilePath))
+            {
+                writer.Write(trimmedDeps, fileStream);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void LoadConflicts()
+        {
+            foreach (var conflict in Conflicts)
+            {
+                string packageId, packageSubPath;
+                NuGetUtilities.GetPackageParts(conflict.ItemSpec, out packageId, out packageSubPath);
+
+                if (String.IsNullOrEmpty(packageId) || String.IsNullOrEmpty(packageSubPath))
+                {
+                    continue;
+                }
+
+                var itemType = conflict.GetMetadata(nameof(ConflictItemType));
+                var conflictPackages = (itemType == nameof(ConflictItemType.Reference)) ? compileConflicts : runtimeConflicts;
+
+                HashSet<string> conflictFiles;
+                if (!conflictPackages.TryGetValue(packageId, out conflictFiles))
+                {
+                    conflictPackages[packageId] = conflictFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                conflictFiles.Add(packageSubPath);
+            }
+        }
+
+        private DependencyContext TrimConflicts(DependencyContext sourceDeps)
+        {
+            return new DependencyContext(sourceDeps.Target,
+                                         sourceDeps.CompilationOptions,
+                                         TrimCompilationLibraries(sourceDeps.CompileLibraries),
+                                         TrimRuntimeLibraries(sourceDeps.RuntimeLibraries),
+                                         sourceDeps.RuntimeGraph);
+        }
+
+        private IEnumerable<RuntimeLibrary> TrimRuntimeLibraries(IReadOnlyList<RuntimeLibrary> runtimeLibraries)
+        {
+            foreach(var runtimeLibrary in runtimeLibraries)
+            {
+                HashSet<string> conflictFiles;
+                if (runtimeConflicts.TryGetValue(runtimeLibrary.Name, out conflictFiles))
+                {
+                    yield return new RuntimeLibrary(runtimeLibrary.Type,
+                                              runtimeLibrary.Name,
+                                              runtimeLibrary.Version,
+                                              runtimeLibrary.Hash,
+                                              TrimAssetGroups(runtimeLibrary.RuntimeAssemblyGroups, conflictFiles).ToArray(),
+                                              TrimAssetGroups(runtimeLibrary.NativeLibraryGroups, conflictFiles).ToArray(),
+                                              TrimResourceAssemblies(runtimeLibrary.ResourceAssemblies, conflictFiles),
+                                              runtimeLibrary.Dependencies,
+                                              runtimeLibrary.Serviceable);
+                }
+                else
+                {
+                    yield return runtimeLibrary;
+                }
+            }
+        }
+
+        private IEnumerable<RuntimeAssetGroup> TrimAssetGroups(IEnumerable<RuntimeAssetGroup> assetGroups, ISet<string> conflicts)
+        {
+            foreach (var assetGroup in assetGroups)
+            {
+                yield return new RuntimeAssetGroup(assetGroup.Runtime, TrimAssemblies(assetGroup.AssetPaths, conflicts));
+            }
+        }
+
+        private IEnumerable<ResourceAssembly> TrimResourceAssemblies(IEnumerable<ResourceAssembly> resourceAssemblies, ISet<string> conflicts)
+        {
+            foreach(var resourceAssembly in resourceAssemblies)
+            {
+                if (!conflicts.Contains(resourceAssembly.Path))
+                {
+                    yield return resourceAssembly;
+                }
+            }
+        }
+
+        private IEnumerable<CompilationLibrary> TrimCompilationLibraries(IReadOnlyList<CompilationLibrary> compileLibraries)
+        {
+            foreach (var compileLibrary in compileLibraries)
+            {
+                HashSet<string> conflictFiles;
+                if (compileConflicts.TryGetValue(compileLibrary.Name, out conflictFiles))
+                {
+                    yield return new CompilationLibrary(compileLibrary.Type,
+                                              compileLibrary.Name,
+                                              compileLibrary.Version,
+                                              compileLibrary.Hash,
+                                              TrimAssemblies(compileLibrary.Assemblies, conflictFiles),
+                                              compileLibrary.Dependencies,
+                                              compileLibrary.Serviceable);
+                }
+                else
+                {
+                    yield return compileLibrary;
+                }
+            }
+        }
+
+        private IEnumerable<string> TrimAssemblies(IEnumerable<string> assemblies, ISet<string> conflicts)
+        {
+            foreach(var assembly in assemblies)
+            {
+                if (!conflicts.Contains(assembly))
+                {
+                    yield return assembly;
+                }
+            }
+        }
+    }
+}

--- a/netstandard/tools/project.json
+++ b/netstandard/tools/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "NETStandard.Library": "1.6.0",
     "System.Reflection.Metadata": "1.3.0"
   },
@@ -19,9 +20,9 @@
       },
       "imports": [ "dnxcore50", "portable-net45+win8+wpa81" ]
     },
-    "net45": {
+    "net451": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.5.1": "1.0.1"
       }
     }
   }

--- a/netstandard/tools/targets/NETStandard.Library.targets
+++ b/netstandard/tools/targets/NETStandard.Library.targets
@@ -18,6 +18,10 @@
       <PropertyGroup>
         <HandlePackageFileConflictsAfter>ResolvePackageDependenciesForBuild</HandlePackageFileConflictsAfter>
         <HandlePublishFileConflictsAfter>RunResolvePublishAssemblies</HandlePublishFileConflictsAfter>
+        <RemoveDepsFileConflictsAfter>GenerateBuildDependencyFile</RemoveDepsFileConflictsAfter>
+        <!-- If CopyLocalLockFileAssemblies is not true the host will run from packages,
+             but we still need to consider those package items for conflicts -->
+        <HandlePackageFileConflictsDependsOn Condition="'$(CopyLocalLockFileAssemblies)' != 'true'">_GetLockFileAssemblies</HandlePackageFileConflictsDependsOn>
       </PropertyGroup>
     </When>
     <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
@@ -53,15 +57,33 @@
     </ReferenceCopyLocalPaths>
   </ItemGroup>
 
+  <Target Name="_GetLockFileAssemblies"
+          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+                            _DefaultMicrosoftNETPlatformLibrary">
+    <!-- Essentially a copy of the SDKs RunResolvePublishAssemblies.
+         We need to find all the files that will be loaded from deps for conflict resolution.-->
+    <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
+                              AssetsFilePath="$(ProjectAssetsFile)"
+                              TargetFramework="$(TargetFrameworkMoniker)"
+                              RuntimeIdentifier="$(RuntimeIdentifier)"
+                              PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
+
+      <Output TaskParameter="AssembliesToPublish" ItemName="_LockFileAssemblies" />
+
+    </ResolvePublishAssemblies>
+  </Target>
+
   <UsingTask TaskName="HandlePackageFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
-  <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)">
+  <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)" DependsOnTargets="$(HandlePackageFileConflictsDependsOn)">
     <HandlePackageFileConflicts References="@(Reference)"
                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                                PlatformItems="@(PackageConflictPlatformItems)"
+                                OtherRuntimeItems="@(_LockFileAssemblies)"
                                 PlatformManifests="@(PackageConflictPlatformManifests)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
+      <Output TaskParameter="Conflicts" ItemName="_ConflictPackageFiles" />
     </HandlePackageFileConflicts>
 
     <!-- Replace Reference / ReferenceCopyLocalPaths with the filtered lists.
@@ -74,6 +96,19 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsWithoutConflicts)" />
     </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <_RemoveDepsFileConflictsSemaphore>$(IntermediateOutputPath)\RemoveDepsFileConflicts.semaphore</_RemoveDepsFileConflictsSemaphore>
+  </PropertyGroup>
+  <UsingTask TaskName="RemoveDepsFileConflicts" AssemblyFile="$(NETStandardToolsTaskDirectory)NETStandard.Tools.dll" />
+  <Target Name="RemoveDepsFileConflicts" AfterTargets="$(RemoveDepsFileConflictsAfter)"
+          Inputs="$(ProjectDepsFilePath)" Outputs="$(_RemoveDepsFileConflictsSemaphore)">
+    <RemoveDepsFileConflicts DepsFilePath="$(ProjectDepsFilePath)" Conflicts="@(_ConflictPackageFiles)" />
+
+    <Touch Files="$(_RemoveDepsFileConflictsSemaphore)" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
   </Target>
 
   <Target Name="HandlePublishFileConflicts" AfterTargets="$(HandlePublishFileConflictsAfter)">


### PR DESCRIPTION
Add a target to read publish-only items from the lock file and
consider these items for conflicts.

Persist the conflicts then remove them from the deps file.

RemoveDepsFileConflicts and _GetLockFileAssemblies are temporary I
expect these to be rewritten in the SDK.  I've tried to factor the
conflict resolution algorithm to be more reusable.

/cc @weshaggard @eerhardt 