### PR TITLE
Add System.Transactions.dll to Xamarin

### DIFF
--- a/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/netstandard/src/ApiCompatBaseline.net461.txt
@@ -1,7 +1,6 @@
 Compat issues with assembly netstandard:
 MembersMustExist : Member 'System.AppContext.GetData(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.AppContext.TargetFrameworkName.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Diagnostics.Tracing.EventCounter' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.add_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.remove_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.
@@ -40,4 +39,4 @@ MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.get()' 
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 41
+Total Issues: 40

--- a/netstandard/src/ApiCompatBaseline.xamarin.android.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.android.txt
@@ -1,38 +1,17 @@
 Compat issues with assembly netstandard:
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.CommittableTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentCloneOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Enlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnlistmentOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnterpriseServicesInteropOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.HostCurrentTransactionCallback' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IDtcTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IEnlistmentNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IPromotableSinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISimpleTransactionSuperior' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IsolationLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ITransactionPromoter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.PreparingEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SinglePhaseEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SubordinateTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Transaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionAbortedException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionCompletedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInDoubtException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInformation' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInterop' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManager' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManagerCommunicationException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionPromotionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScope' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeAsyncFlowOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStartedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStatus' does not exist in the implementation but it does exist in the contract.
-Total Issues: 36
+MembersMustExist : Member 'System.Transactions.Transaction.EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.GetPromotedToken()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoteAndEnlistDurable(System.Guid, System.Transactions.IPromotableSinglePhaseNotification, System.Transactions.ISinglePhaseNotification, System.Transactions.EnlistmentOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoterType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionCompletedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionInDoubtException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Guid System.Transactions.TransactionInterop.PromoterTypeDtc' does not exist in the implementation but it does exist in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionManagerCommunicationException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionPromotionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.TimeSpan, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.TransactionScopeOption, System.Transactions.TransactionOptions, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionStartedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+Total Issues: 15

--- a/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
@@ -1,38 +1,17 @@
 Compat issues with assembly netstandard:
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.CommittableTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentCloneOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Enlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnlistmentOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnterpriseServicesInteropOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.HostCurrentTransactionCallback' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IDtcTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IEnlistmentNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IPromotableSinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISimpleTransactionSuperior' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IsolationLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ITransactionPromoter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.PreparingEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SinglePhaseEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SubordinateTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Transaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionAbortedException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionCompletedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInDoubtException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInformation' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInterop' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManager' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManagerCommunicationException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionPromotionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScope' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeAsyncFlowOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStartedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStatus' does not exist in the implementation but it does exist in the contract.
-Total Issues: 36
+MembersMustExist : Member 'System.Transactions.Transaction.EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.GetPromotedToken()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoteAndEnlistDurable(System.Guid, System.Transactions.IPromotableSinglePhaseNotification, System.Transactions.ISinglePhaseNotification, System.Transactions.EnlistmentOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoterType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionCompletedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionInDoubtException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Guid System.Transactions.TransactionInterop.PromoterTypeDtc' does not exist in the implementation but it does exist in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionManagerCommunicationException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionPromotionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.TimeSpan, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.TransactionScopeOption, System.Transactions.TransactionOptions, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionStartedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+Total Issues: 15

--- a/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
@@ -1,38 +1,17 @@
 Compat issues with assembly netstandard:
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.CommittableTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentCloneOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Enlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnlistmentOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnterpriseServicesInteropOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.HostCurrentTransactionCallback' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IDtcTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IEnlistmentNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IPromotableSinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISimpleTransactionSuperior' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IsolationLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ITransactionPromoter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.PreparingEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SinglePhaseEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SubordinateTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Transaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionAbortedException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionCompletedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInDoubtException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInformation' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInterop' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManager' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManagerCommunicationException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionPromotionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScope' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeAsyncFlowOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStartedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStatus' does not exist in the implementation but it does exist in the contract.
-Total Issues: 36
+MembersMustExist : Member 'System.Transactions.Transaction.EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.GetPromotedToken()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoteAndEnlistDurable(System.Guid, System.Transactions.IPromotableSinglePhaseNotification, System.Transactions.ISinglePhaseNotification, System.Transactions.EnlistmentOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoterType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionCompletedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionInDoubtException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Guid System.Transactions.TransactionInterop.PromoterTypeDtc' does not exist in the implementation but it does exist in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionManagerCommunicationException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionPromotionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.TimeSpan, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.TransactionScopeOption, System.Transactions.TransactionOptions, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionStartedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+Total Issues: 15

--- a/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
@@ -1,38 +1,17 @@
 Compat issues with assembly netstandard:
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.CommittableTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentCloneOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Enlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnlistmentOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnterpriseServicesInteropOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.HostCurrentTransactionCallback' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IDtcTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IEnlistmentNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IPromotableSinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISimpleTransactionSuperior' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IsolationLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ITransactionPromoter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.PreparingEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SinglePhaseEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SubordinateTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Transaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionAbortedException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionCompletedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInDoubtException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInformation' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInterop' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManager' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManagerCommunicationException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionPromotionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScope' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeAsyncFlowOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStartedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStatus' does not exist in the implementation but it does exist in the contract.
-Total Issues: 36
+MembersMustExist : Member 'System.Transactions.Transaction.EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.GetPromotedToken()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoteAndEnlistDurable(System.Guid, System.Transactions.IPromotableSinglePhaseNotification, System.Transactions.ISinglePhaseNotification, System.Transactions.EnlistmentOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoterType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionCompletedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionInDoubtException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Guid System.Transactions.TransactionInterop.PromoterTypeDtc' does not exist in the implementation but it does exist in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionManagerCommunicationException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionPromotionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.TimeSpan, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.TransactionScopeOption, System.Transactions.TransactionOptions, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionStartedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+Total Issues: 15

--- a/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
@@ -1,38 +1,17 @@
 Compat issues with assembly netstandard:
-MembersMustExist : Member 'System.Data.Common.DbConnection.EnlistTransaction(System.Transactions.Transaction)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.CommittableTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentCloneOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.DependentTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Enlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnlistmentOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.EnterpriseServicesInteropOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.HostCurrentTransactionCallback' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IDtcTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IEnlistmentNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IPromotableSinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISimpleTransactionSuperior' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ISinglePhaseNotification' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.IsolationLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.ITransactionPromoter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.PreparingEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SinglePhaseEnlistment' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.SubordinateTransaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.Transaction' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionAbortedException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionCompletedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInDoubtException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInformation' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionInterop' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManager' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionManagerCommunicationException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionPromotionException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScope' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeAsyncFlowOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionScopeOption' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStartedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Transactions.TransactionStatus' does not exist in the implementation but it does exist in the contract.
-Total Issues: 36
+MembersMustExist : Member 'System.Transactions.Transaction.EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.GetPromotedToken()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoteAndEnlistDurable(System.Guid, System.Transactions.IPromotableSinglePhaseNotification, System.Transactions.ISinglePhaseNotification, System.Transactions.EnlistmentOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.PromoterType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.Transaction.SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification, System.Guid)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionCompletedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionInDoubtException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Guid System.Transactions.TransactionInterop.PromoterTypeDtc' does not exist in the implementation but it does exist in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionManagerCommunicationException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+CannotMakeMoreVisible : Visibility of member 'System.Transactions.TransactionPromotionException..ctor()' is 'Family' in the implementation but 'Public' in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.TimeSpan, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.Transaction, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Transactions.TransactionScope..ctor(System.Transactions.TransactionScopeOption, System.Transactions.TransactionOptions, System.Transactions.TransactionScopeAsyncFlowOption)' does not exist in the implementation but it does exist in the contract.
+DelegateParamNameMustMatch : Parameter name on delegate 'System.Transactions.TransactionStartedEventHandler' is 'o' in the implementation but 'sender' in the contract.
+Total Issues: 15

--- a/netstandard/src/netstandard.csproj
+++ b/netstandard/src/netstandard.csproj
@@ -25,13 +25,13 @@
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Net.Http.csproj" />
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Numerics.csproj" />
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Runtime.Serialization.csproj" />
+    <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Transactions.csproj" />
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Xml.csproj" />
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Xml.Linq.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='net461'">
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Web.csproj" />
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Drawing.csproj" />
-    <ProjectReference Include="..\..\platforms\$(TargetGroup)\System.Transactions.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='xamarin.ios'">
     <ProjectReference Include="..\..\platforms\$(TargetGroup)\OpenTK-1.0.csproj" />

--- a/platforms/net461/System.Data.cs
+++ b/platforms/net461/System.Data.cs
@@ -2168,7 +2168,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/net461/System.Data.csproj
+++ b/platforms/net461/System.Data.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
     <ProjectReference Include="System.csproj" />
+    <ProjectReference Include="System.Transactions.csproj" />
     <ProjectReference Include="System.Xml.csproj" />
     <Compile Include="System.Data.cs" />
   </ItemGroup>

--- a/platforms/xamarin.android/System.Core.cs
+++ b/platforms/xamarin.android/System.Core.cs
@@ -2284,6 +2284,25 @@ namespace System.Runtime.CompilerServices
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : System.Reflection.EventInfo
+    {
+        public ComAwareEventInfo(System.Type type, string eventName) { }
+        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
+        public override System.Type DeclaringType { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override System.Type ReflectedType { get { throw null; } }
+        public override void AddEventHandler(object target, System.Delegate handler) { }
+        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override void RemoveEventHandler(object target, System.Delegate handler) { }
+    }
+}
 namespace System.Security.Cryptography
 {
     public sealed partial class AesCng : System.Security.Cryptography.Aes

--- a/platforms/xamarin.android/System.Data.cs
+++ b/platforms/xamarin.android/System.Data.cs
@@ -2131,7 +2131,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/xamarin.android/System.Transactions.cs
+++ b/platforms/xamarin.android/System.Transactions.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Transactions
+{
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        public CommittableTransaction() { }
+        public CommittableTransaction(System.TimeSpan timeout) { }
+        public CommittableTransaction(System.Transactions.TransactionOptions options) { }
+        object System.IAsyncResult.AsyncState { get { throw null; } }
+        System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
+        bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
+        bool System.IAsyncResult.IsCompleted { get { throw null; } }
+        public System.IAsyncResult BeginCommit(System.AsyncCallback callback, object user_defined_state) { throw null; }
+        public void Commit() { }
+        public void EndCommit(System.IAsyncResult ar) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public enum DependentCloneOption
+    {
+        BlockCommitUntilComplete = 0,
+        RollbackIfNotComplete = 1,
+    }
+    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    {
+        internal DependentTransaction() { }
+        public void Complete() { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class Enlistment
+    {
+        internal Enlistment() { }
+        public void Done() { }
+    }
+    [System.FlagsAttribute]
+    public enum EnlistmentOptions
+    {
+        EnlistDuringPrepareRequired = 1,
+        None = 0,
+    }
+    public enum EnterpriseServicesInteropOption
+    {
+        Automatic = 1,
+        Full = 2,
+        None = 0,
+    }
+    public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
+    public partial interface IDtcTransaction
+    {
+        void Abort(System.IntPtr manager, int whatever, int whatever2);
+        void Commit(int whatever, int whatever2, int whatever3);
+        void GetTransactionInfo(System.IntPtr whatever);
+    }
+    public partial interface IEnlistmentNotification
+    {
+        void Commit(System.Transactions.Enlistment enlistment);
+        void InDoubt(System.Transactions.Enlistment enlistment);
+        void Prepare(System.Transactions.PreparingEnlistment preparingEnlistment);
+        void Rollback(System.Transactions.Enlistment enlistment);
+    }
+    public partial interface IPromotableSinglePhaseNotification : System.Transactions.ITransactionPromoter
+    {
+        void Initialize();
+        void Rollback(System.Transactions.SinglePhaseEnlistment enlistment);
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public partial interface ISimpleTransactionSuperior : System.Transactions.ITransactionPromoter
+    {
+        void Rollback();
+    }
+    public partial interface ISinglePhaseNotification : System.Transactions.IEnlistmentNotification
+    {
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public enum IsolationLevel
+    {
+        Chaos = 5,
+        ReadCommitted = 2,
+        ReadUncommitted = 3,
+        RepeatableRead = 1,
+        Serializable = 0,
+        Snapshot = 4,
+        Unspecified = 6,
+    }
+    public partial interface ITransactionPromoter
+    {
+        byte[] Promote();
+    }
+    public partial class PreparingEnlistment : System.Transactions.Enlistment
+    {
+        internal PreparingEnlistment() { }
+        public void ForceRollback() { }
+        public void ForceRollback(System.Exception ex) { }
+        public void Prepared() { }
+        public byte[] RecoveryInformation() { throw null; }
+    }
+    public partial class SinglePhaseEnlistment : System.Transactions.Enlistment
+    {
+        internal SinglePhaseEnlistment() { }
+        public void Aborted() { }
+        public void Aborted(System.Exception e) { }
+        public void Committed() { }
+        public void InDoubt() { }
+        public void InDoubt(System.Exception e) { }
+    }
+    public sealed partial class SubordinateTransaction : System.Transactions.Transaction
+    {
+        public SubordinateTransaction(System.Transactions.IsolationLevel level, System.Transactions.ISimpleTransactionSuperior superior) { }
+    }
+    public partial class Transaction : System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        internal Transaction() { }
+        public static System.Transactions.Transaction Current { get { throw null; } set { } }
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
+        public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
+        public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
+        protected System.IAsyncResult BeginCommitInternal(System.AsyncCallback callback) { throw null; }
+        public System.Transactions.Transaction Clone() { throw null; }
+        public System.Transactions.DependentTransaction DependentClone(System.Transactions.DependentCloneOption option) { throw null; }
+        public void Dispose() { }
+        protected void EndCommitInternal(System.IAsyncResult ar) { }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public bool EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification notification) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public static bool operator !=(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public void Rollback() { }
+        public void Rollback(System.Exception ex) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TransactionAbortedException : System.Transactions.TransactionException
+    {
+        public TransactionAbortedException() { }
+        protected TransactionAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionAbortedException(string message) { }
+        public TransactionAbortedException(string message, System.Exception innerException) { }
+    }
+    public delegate void TransactionCompletedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public partial class TransactionEventArgs : System.EventArgs
+    {
+        public TransactionEventArgs() { }
+        public System.Transactions.Transaction Transaction { get { throw null; } }
+    }
+    public partial class TransactionException : System.SystemException
+    {
+        protected TransactionException() { }
+        protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionException(string message) { }
+        public TransactionException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInDoubtException : System.Transactions.TransactionException
+    {
+        protected TransactionInDoubtException() { }
+        protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionInDoubtException(string message) { }
+        public TransactionInDoubtException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInformation
+    {
+        internal TransactionInformation() { }
+        public System.DateTime CreationTime { get { throw null; } }
+        public System.Guid DistributedIdentifier { get { throw null; } }
+        public string LocalIdentifier { get { throw null; } }
+        public System.Transactions.TransactionStatus Status { get { throw null; } }
+    }
+    public static partial class TransactionInterop
+    {
+        public static System.Transactions.IDtcTransaction GetDtcTransaction(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetExportCookie(System.Transactions.Transaction transaction, byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromDtcTransaction(System.Transactions.IDtcTransaction dtc) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromExportCookie(byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromTransmitterPropagationToken(byte[] token) { throw null; }
+        public static byte[] GetTransmitterPropagationToken(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetWhereabouts() { throw null; }
+    }
+    public static partial class TransactionManager
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.Transactions.HostCurrentTransactionCallback HostCurrentCallback { get { throw null; } set { } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static event System.Transactions.TransactionStartedEventHandler DistributedTransactionStarted { add { } remove { } }
+        public static void RecoveryComplete(System.Guid manager) { }
+        public static System.Transactions.Enlistment Reenlist(System.Guid manager, byte[] recoveryInfo, System.Transactions.IEnlistmentNotification notification) { throw null; }
+    }
+    public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
+    {
+        protected TransactionManagerCommunicationException() { }
+        protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionManagerCommunicationException(string message) { }
+        public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct TransactionOptions
+    {
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
+        public System.TimeSpan Timeout { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+    }
+    public partial class TransactionPromotionException : System.Transactions.TransactionException
+    {
+        protected TransactionPromotionException() { }
+        protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionPromotionException(string message) { }
+        public TransactionPromotionException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class TransactionScope : System.IDisposable
+    {
+        public TransactionScope() { }
+        public TransactionScope(System.Transactions.Transaction transaction) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public void Complete() { }
+        public void Dispose() { }
+    }
+    public enum TransactionScopeAsyncFlowOption
+    {
+        Enabled = 1,
+        Suppress = 0,
+    }
+    public enum TransactionScopeOption
+    {
+        Required = 0,
+        RequiresNew = 1,
+        Suppress = 2,
+    }
+    public delegate void TransactionStartedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public enum TransactionStatus
+    {
+        Aborted = 2,
+        Active = 0,
+        Committed = 1,
+        InDoubt = 3,
+    }
+}

--- a/platforms/xamarin.android/System.Transactions.csproj
+++ b/platforms/xamarin.android/System.Transactions.csproj
@@ -10,10 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
-    <ProjectReference Include="System.csproj" />
-    <ProjectReference Include="System.Transactions.csproj" />
-    <ProjectReference Include="System.Xml.csproj" />
-    <Compile Include="System.Data.cs" />
+    <Compile Include="System.Transactions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/platforms/xamarin.android/mscorlib.cs
+++ b/platforms/xamarin.android/mscorlib.cs
@@ -11902,22 +11902,6 @@ namespace System.Runtime.InteropServices
         public ComAliasNameAttribute(string alias) { }
         public string Value { get { throw null; } }
     }
-    public partial class ComAwareEventInfo : System.Reflection.EventInfo
-    {
-        public ComAwareEventInfo(System.Type type, string eventName) { }
-        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
-        public override System.Type DeclaringType { get { throw null; } }
-        public override string Name { get { throw null; } }
-        public override System.Type ReflectedType { get { throw null; } }
-        public override void AddEventHandler(object target, System.Delegate handler) { }
-        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-        public override object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override void RemoveEventHandler(object target, System.Delegate handler) { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class ComCompatibleVersionAttribute : System.Attribute
     {
@@ -12440,6 +12424,7 @@ namespace System.Runtime.InteropServices
         public static object BindToMoniker(string monikerName) { throw null; }
         public static System.IntPtr BufferToBSTR(System.Array ptr, int slen) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
@@ -17558,7 +17543,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public IncrementalHash() { }
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }

--- a/platforms/xamarin.ios/System.Core.cs
+++ b/platforms/xamarin.ios/System.Core.cs
@@ -2262,6 +2262,25 @@ namespace System.Runtime.CompilerServices
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : System.Reflection.EventInfo
+    {
+        public ComAwareEventInfo(System.Type type, string eventName) { }
+        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
+        public override System.Type DeclaringType { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override System.Type ReflectedType { get { throw null; } }
+        public override void AddEventHandler(object target, System.Delegate handler) { }
+        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override void RemoveEventHandler(object target, System.Delegate handler) { }
+    }
+}
 namespace System.Security.Cryptography
 {
     public sealed partial class AesCng : System.Security.Cryptography.Aes

--- a/platforms/xamarin.ios/System.Data.cs
+++ b/platforms/xamarin.ios/System.Data.cs
@@ -2131,7 +2131,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/xamarin.ios/System.Data.csproj
+++ b/platforms/xamarin.ios/System.Data.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
     <ProjectReference Include="System.csproj" />
+    <ProjectReference Include="System.Transactions.csproj" />
     <ProjectReference Include="System.Xml.csproj" />
     <Compile Include="System.Data.cs" />
   </ItemGroup>

--- a/platforms/xamarin.ios/System.Transactions.cs
+++ b/platforms/xamarin.ios/System.Transactions.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Transactions
+{
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        public CommittableTransaction() { }
+        public CommittableTransaction(System.TimeSpan timeout) { }
+        public CommittableTransaction(System.Transactions.TransactionOptions options) { }
+        object System.IAsyncResult.AsyncState { get { throw null; } }
+        System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
+        bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
+        bool System.IAsyncResult.IsCompleted { get { throw null; } }
+        public System.IAsyncResult BeginCommit(System.AsyncCallback callback, object user_defined_state) { throw null; }
+        public void Commit() { }
+        public void EndCommit(System.IAsyncResult ar) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public enum DependentCloneOption
+    {
+        BlockCommitUntilComplete = 0,
+        RollbackIfNotComplete = 1,
+    }
+    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    {
+        internal DependentTransaction() { }
+        public void Complete() { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class Enlistment
+    {
+        internal Enlistment() { }
+        public void Done() { }
+    }
+    [System.FlagsAttribute]
+    public enum EnlistmentOptions
+    {
+        EnlistDuringPrepareRequired = 1,
+        None = 0,
+    }
+    public enum EnterpriseServicesInteropOption
+    {
+        Automatic = 1,
+        Full = 2,
+        None = 0,
+    }
+    public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
+    public partial interface IDtcTransaction
+    {
+        void Abort(System.IntPtr manager, int whatever, int whatever2);
+        void Commit(int whatever, int whatever2, int whatever3);
+        void GetTransactionInfo(System.IntPtr whatever);
+    }
+    public partial interface IEnlistmentNotification
+    {
+        void Commit(System.Transactions.Enlistment enlistment);
+        void InDoubt(System.Transactions.Enlistment enlistment);
+        void Prepare(System.Transactions.PreparingEnlistment preparingEnlistment);
+        void Rollback(System.Transactions.Enlistment enlistment);
+    }
+    public partial interface IPromotableSinglePhaseNotification : System.Transactions.ITransactionPromoter
+    {
+        void Initialize();
+        void Rollback(System.Transactions.SinglePhaseEnlistment enlistment);
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public partial interface ISimpleTransactionSuperior : System.Transactions.ITransactionPromoter
+    {
+        void Rollback();
+    }
+    public partial interface ISinglePhaseNotification : System.Transactions.IEnlistmentNotification
+    {
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public enum IsolationLevel
+    {
+        Chaos = 5,
+        ReadCommitted = 2,
+        ReadUncommitted = 3,
+        RepeatableRead = 1,
+        Serializable = 0,
+        Snapshot = 4,
+        Unspecified = 6,
+    }
+    public partial interface ITransactionPromoter
+    {
+        byte[] Promote();
+    }
+    public partial class PreparingEnlistment : System.Transactions.Enlistment
+    {
+        internal PreparingEnlistment() { }
+        public void ForceRollback() { }
+        public void ForceRollback(System.Exception ex) { }
+        public void Prepared() { }
+        public byte[] RecoveryInformation() { throw null; }
+    }
+    public partial class SinglePhaseEnlistment : System.Transactions.Enlistment
+    {
+        internal SinglePhaseEnlistment() { }
+        public void Aborted() { }
+        public void Aborted(System.Exception e) { }
+        public void Committed() { }
+        public void InDoubt() { }
+        public void InDoubt(System.Exception e) { }
+    }
+    public sealed partial class SubordinateTransaction : System.Transactions.Transaction
+    {
+        public SubordinateTransaction(System.Transactions.IsolationLevel level, System.Transactions.ISimpleTransactionSuperior superior) { }
+    }
+    public partial class Transaction : System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        internal Transaction() { }
+        public static System.Transactions.Transaction Current { get { throw null; } set { } }
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
+        public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
+        public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
+        protected System.IAsyncResult BeginCommitInternal(System.AsyncCallback callback) { throw null; }
+        public System.Transactions.Transaction Clone() { throw null; }
+        public System.Transactions.DependentTransaction DependentClone(System.Transactions.DependentCloneOption option) { throw null; }
+        public void Dispose() { }
+        protected void EndCommitInternal(System.IAsyncResult ar) { }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public bool EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification notification) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public static bool operator !=(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public void Rollback() { }
+        public void Rollback(System.Exception ex) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TransactionAbortedException : System.Transactions.TransactionException
+    {
+        public TransactionAbortedException() { }
+        protected TransactionAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionAbortedException(string message) { }
+        public TransactionAbortedException(string message, System.Exception innerException) { }
+    }
+    public delegate void TransactionCompletedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public partial class TransactionEventArgs : System.EventArgs
+    {
+        public TransactionEventArgs() { }
+        public System.Transactions.Transaction Transaction { get { throw null; } }
+    }
+    public partial class TransactionException : System.SystemException
+    {
+        protected TransactionException() { }
+        protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionException(string message) { }
+        public TransactionException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInDoubtException : System.Transactions.TransactionException
+    {
+        protected TransactionInDoubtException() { }
+        protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionInDoubtException(string message) { }
+        public TransactionInDoubtException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInformation
+    {
+        internal TransactionInformation() { }
+        public System.DateTime CreationTime { get { throw null; } }
+        public System.Guid DistributedIdentifier { get { throw null; } }
+        public string LocalIdentifier { get { throw null; } }
+        public System.Transactions.TransactionStatus Status { get { throw null; } }
+    }
+    public static partial class TransactionInterop
+    {
+        public static System.Transactions.IDtcTransaction GetDtcTransaction(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetExportCookie(System.Transactions.Transaction transaction, byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromDtcTransaction(System.Transactions.IDtcTransaction dtc) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromExportCookie(byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromTransmitterPropagationToken(byte[] token) { throw null; }
+        public static byte[] GetTransmitterPropagationToken(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetWhereabouts() { throw null; }
+    }
+    public static partial class TransactionManager
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.Transactions.HostCurrentTransactionCallback HostCurrentCallback { get { throw null; } set { } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static event System.Transactions.TransactionStartedEventHandler DistributedTransactionStarted { add { } remove { } }
+        public static void RecoveryComplete(System.Guid manager) { }
+        public static System.Transactions.Enlistment Reenlist(System.Guid manager, byte[] recoveryInfo, System.Transactions.IEnlistmentNotification notification) { throw null; }
+    }
+    public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
+    {
+        protected TransactionManagerCommunicationException() { }
+        protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionManagerCommunicationException(string message) { }
+        public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct TransactionOptions
+    {
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
+        public System.TimeSpan Timeout { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+    }
+    public partial class TransactionPromotionException : System.Transactions.TransactionException
+    {
+        protected TransactionPromotionException() { }
+        protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionPromotionException(string message) { }
+        public TransactionPromotionException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class TransactionScope : System.IDisposable
+    {
+        public TransactionScope() { }
+        public TransactionScope(System.Transactions.Transaction transaction) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public void Complete() { }
+        public void Dispose() { }
+    }
+    public enum TransactionScopeAsyncFlowOption
+    {
+        Enabled = 1,
+        Suppress = 0,
+    }
+    public enum TransactionScopeOption
+    {
+        Required = 0,
+        RequiresNew = 1,
+        Suppress = 2,
+    }
+    public delegate void TransactionStartedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public enum TransactionStatus
+    {
+        Aborted = 2,
+        Active = 0,
+        Committed = 1,
+        InDoubt = 3,
+    }
+}

--- a/platforms/xamarin.ios/System.Transactions.csproj
+++ b/platforms/xamarin.ios/System.Transactions.csproj
@@ -10,10 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
-    <ProjectReference Include="System.csproj" />
-    <ProjectReference Include="System.Transactions.csproj" />
-    <ProjectReference Include="System.Xml.csproj" />
-    <Compile Include="System.Data.cs" />
+    <Compile Include="System.Transactions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/platforms/xamarin.ios/System.cs
+++ b/platforms/xamarin.ios/System.cs
@@ -479,7 +479,7 @@ namespace Mono.Security.Interface
         public static bool IsInitialized { get { throw null; } }
         public static System.Net.HttpListener CreateHttpListener(System.Security.Cryptography.X509Certificates.X509Certificate certificate, Mono.Security.Interface.MonoTlsProvider provider=null, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
         public static System.Net.HttpWebRequest CreateHttpsRequest(System.Uri requestUri, Mono.Security.Interface.MonoTlsProvider provider, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use GetProvider() instead.")]
         public static Mono.Security.Interface.MonoTlsProvider GetDefaultProvider() { throw null; }
         public static Mono.Security.Interface.IMonoSslStream GetMonoSslStream(System.Net.Security.SslStream stream) { throw null; }
         public static Mono.Security.Interface.MonoTlsProvider GetProvider() { throw null; }
@@ -487,7 +487,7 @@ namespace Mono.Security.Interface
         public static void Initialize() { }
         public static void Initialize(string provider) { }
         public static bool IsProviderSupported(string provider) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use Initialize(string provider) instead.")]
         public static void SetDefaultProvider(string name) { }
     }
     public sealed partial class MonoTlsSettings

--- a/platforms/xamarin.ios/mscorlib.cs
+++ b/platforms/xamarin.ios/mscorlib.cs
@@ -11172,22 +11172,6 @@ namespace System.Runtime.InteropServices
         public ComAliasNameAttribute(string alias) { }
         public string Value { get { throw null; } }
     }
-    public partial class ComAwareEventInfo : System.Reflection.EventInfo
-    {
-        public ComAwareEventInfo(System.Type type, string eventName) { }
-        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
-        public override System.Type DeclaringType { get { throw null; } }
-        public override string Name { get { throw null; } }
-        public override System.Type ReflectedType { get { throw null; } }
-        public override void AddEventHandler(object target, System.Delegate handler) { }
-        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-        public override object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override void RemoveEventHandler(object target, System.Delegate handler) { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class ComCompatibleVersionAttribute : System.Attribute
     {
@@ -11676,6 +11660,7 @@ namespace System.Runtime.InteropServices
         public static object BindToMoniker(string monikerName) { throw null; }
         public static System.IntPtr BufferToBSTR(System.Array ptr, int slen) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
@@ -16547,7 +16532,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public IncrementalHash() { }
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }

--- a/platforms/xamarin.mac/System.Core.cs
+++ b/platforms/xamarin.mac/System.Core.cs
@@ -2284,6 +2284,25 @@ namespace System.Runtime.CompilerServices
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : System.Reflection.EventInfo
+    {
+        public ComAwareEventInfo(System.Type type, string eventName) { }
+        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
+        public override System.Type DeclaringType { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override System.Type ReflectedType { get { throw null; } }
+        public override void AddEventHandler(object target, System.Delegate handler) { }
+        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override void RemoveEventHandler(object target, System.Delegate handler) { }
+    }
+}
 namespace System.Security.Cryptography
 {
     public sealed partial class AesCng : System.Security.Cryptography.Aes

--- a/platforms/xamarin.mac/System.Data.cs
+++ b/platforms/xamarin.mac/System.Data.cs
@@ -2131,7 +2131,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/xamarin.mac/System.Data.csproj
+++ b/platforms/xamarin.mac/System.Data.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
     <ProjectReference Include="System.csproj" />
+    <ProjectReference Include="System.Transactions.csproj" />
     <ProjectReference Include="System.Xml.csproj" />
     <Compile Include="System.Data.cs" />
   </ItemGroup>

--- a/platforms/xamarin.mac/System.Transactions.cs
+++ b/platforms/xamarin.mac/System.Transactions.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Transactions
+{
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        public CommittableTransaction() { }
+        public CommittableTransaction(System.TimeSpan timeout) { }
+        public CommittableTransaction(System.Transactions.TransactionOptions options) { }
+        object System.IAsyncResult.AsyncState { get { throw null; } }
+        System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
+        bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
+        bool System.IAsyncResult.IsCompleted { get { throw null; } }
+        public System.IAsyncResult BeginCommit(System.AsyncCallback callback, object user_defined_state) { throw null; }
+        public void Commit() { }
+        public void EndCommit(System.IAsyncResult ar) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public enum DependentCloneOption
+    {
+        BlockCommitUntilComplete = 0,
+        RollbackIfNotComplete = 1,
+    }
+    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    {
+        internal DependentTransaction() { }
+        public void Complete() { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class Enlistment
+    {
+        internal Enlistment() { }
+        public void Done() { }
+    }
+    [System.FlagsAttribute]
+    public enum EnlistmentOptions
+    {
+        EnlistDuringPrepareRequired = 1,
+        None = 0,
+    }
+    public enum EnterpriseServicesInteropOption
+    {
+        Automatic = 1,
+        Full = 2,
+        None = 0,
+    }
+    public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
+    public partial interface IDtcTransaction
+    {
+        void Abort(System.IntPtr manager, int whatever, int whatever2);
+        void Commit(int whatever, int whatever2, int whatever3);
+        void GetTransactionInfo(System.IntPtr whatever);
+    }
+    public partial interface IEnlistmentNotification
+    {
+        void Commit(System.Transactions.Enlistment enlistment);
+        void InDoubt(System.Transactions.Enlistment enlistment);
+        void Prepare(System.Transactions.PreparingEnlistment preparingEnlistment);
+        void Rollback(System.Transactions.Enlistment enlistment);
+    }
+    public partial interface IPromotableSinglePhaseNotification : System.Transactions.ITransactionPromoter
+    {
+        void Initialize();
+        void Rollback(System.Transactions.SinglePhaseEnlistment enlistment);
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public partial interface ISimpleTransactionSuperior : System.Transactions.ITransactionPromoter
+    {
+        void Rollback();
+    }
+    public partial interface ISinglePhaseNotification : System.Transactions.IEnlistmentNotification
+    {
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public enum IsolationLevel
+    {
+        Chaos = 5,
+        ReadCommitted = 2,
+        ReadUncommitted = 3,
+        RepeatableRead = 1,
+        Serializable = 0,
+        Snapshot = 4,
+        Unspecified = 6,
+    }
+    public partial interface ITransactionPromoter
+    {
+        byte[] Promote();
+    }
+    public partial class PreparingEnlistment : System.Transactions.Enlistment
+    {
+        internal PreparingEnlistment() { }
+        public void ForceRollback() { }
+        public void ForceRollback(System.Exception ex) { }
+        public void Prepared() { }
+        public byte[] RecoveryInformation() { throw null; }
+    }
+    public partial class SinglePhaseEnlistment : System.Transactions.Enlistment
+    {
+        internal SinglePhaseEnlistment() { }
+        public void Aborted() { }
+        public void Aborted(System.Exception e) { }
+        public void Committed() { }
+        public void InDoubt() { }
+        public void InDoubt(System.Exception e) { }
+    }
+    public sealed partial class SubordinateTransaction : System.Transactions.Transaction
+    {
+        public SubordinateTransaction(System.Transactions.IsolationLevel level, System.Transactions.ISimpleTransactionSuperior superior) { }
+    }
+    public partial class Transaction : System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        internal Transaction() { }
+        public static System.Transactions.Transaction Current { get { throw null; } set { } }
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
+        public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
+        public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
+        protected System.IAsyncResult BeginCommitInternal(System.AsyncCallback callback) { throw null; }
+        public System.Transactions.Transaction Clone() { throw null; }
+        public System.Transactions.DependentTransaction DependentClone(System.Transactions.DependentCloneOption option) { throw null; }
+        public void Dispose() { }
+        protected void EndCommitInternal(System.IAsyncResult ar) { }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public bool EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification notification) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public static bool operator !=(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public void Rollback() { }
+        public void Rollback(System.Exception ex) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TransactionAbortedException : System.Transactions.TransactionException
+    {
+        public TransactionAbortedException() { }
+        protected TransactionAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionAbortedException(string message) { }
+        public TransactionAbortedException(string message, System.Exception innerException) { }
+    }
+    public delegate void TransactionCompletedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public partial class TransactionEventArgs : System.EventArgs
+    {
+        public TransactionEventArgs() { }
+        public System.Transactions.Transaction Transaction { get { throw null; } }
+    }
+    public partial class TransactionException : System.SystemException
+    {
+        protected TransactionException() { }
+        protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionException(string message) { }
+        public TransactionException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInDoubtException : System.Transactions.TransactionException
+    {
+        protected TransactionInDoubtException() { }
+        protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionInDoubtException(string message) { }
+        public TransactionInDoubtException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInformation
+    {
+        internal TransactionInformation() { }
+        public System.DateTime CreationTime { get { throw null; } }
+        public System.Guid DistributedIdentifier { get { throw null; } }
+        public string LocalIdentifier { get { throw null; } }
+        public System.Transactions.TransactionStatus Status { get { throw null; } }
+    }
+    public static partial class TransactionInterop
+    {
+        public static System.Transactions.IDtcTransaction GetDtcTransaction(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetExportCookie(System.Transactions.Transaction transaction, byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromDtcTransaction(System.Transactions.IDtcTransaction dtc) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromExportCookie(byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromTransmitterPropagationToken(byte[] token) { throw null; }
+        public static byte[] GetTransmitterPropagationToken(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetWhereabouts() { throw null; }
+    }
+    public static partial class TransactionManager
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.Transactions.HostCurrentTransactionCallback HostCurrentCallback { get { throw null; } set { } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static event System.Transactions.TransactionStartedEventHandler DistributedTransactionStarted { add { } remove { } }
+        public static void RecoveryComplete(System.Guid manager) { }
+        public static System.Transactions.Enlistment Reenlist(System.Guid manager, byte[] recoveryInfo, System.Transactions.IEnlistmentNotification notification) { throw null; }
+    }
+    public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
+    {
+        protected TransactionManagerCommunicationException() { }
+        protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionManagerCommunicationException(string message) { }
+        public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct TransactionOptions
+    {
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
+        public System.TimeSpan Timeout { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+    }
+    public partial class TransactionPromotionException : System.Transactions.TransactionException
+    {
+        protected TransactionPromotionException() { }
+        protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionPromotionException(string message) { }
+        public TransactionPromotionException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class TransactionScope : System.IDisposable
+    {
+        public TransactionScope() { }
+        public TransactionScope(System.Transactions.Transaction transaction) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public void Complete() { }
+        public void Dispose() { }
+    }
+    public enum TransactionScopeAsyncFlowOption
+    {
+        Enabled = 1,
+        Suppress = 0,
+    }
+    public enum TransactionScopeOption
+    {
+        Required = 0,
+        RequiresNew = 1,
+        Suppress = 2,
+    }
+    public delegate void TransactionStartedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public enum TransactionStatus
+    {
+        Aborted = 2,
+        Active = 0,
+        Committed = 1,
+        InDoubt = 3,
+    }
+}

--- a/platforms/xamarin.mac/System.Transactions.csproj
+++ b/platforms/xamarin.mac/System.Transactions.csproj
@@ -10,10 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
-    <ProjectReference Include="System.csproj" />
-    <ProjectReference Include="System.Transactions.csproj" />
-    <ProjectReference Include="System.Xml.csproj" />
-    <Compile Include="System.Data.cs" />
+    <Compile Include="System.Transactions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/platforms/xamarin.mac/System.cs
+++ b/platforms/xamarin.mac/System.cs
@@ -479,7 +479,7 @@ namespace Mono.Security.Interface
         public static bool IsInitialized { get { throw null; } }
         public static System.Net.HttpListener CreateHttpListener(System.Security.Cryptography.X509Certificates.X509Certificate certificate, Mono.Security.Interface.MonoTlsProvider provider=null, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
         public static System.Net.HttpWebRequest CreateHttpsRequest(System.Uri requestUri, Mono.Security.Interface.MonoTlsProvider provider, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use GetProvider() instead.")]
         public static Mono.Security.Interface.MonoTlsProvider GetDefaultProvider() { throw null; }
         public static Mono.Security.Interface.IMonoSslStream GetMonoSslStream(System.Net.Security.SslStream stream) { throw null; }
         public static Mono.Security.Interface.MonoTlsProvider GetProvider() { throw null; }
@@ -487,7 +487,7 @@ namespace Mono.Security.Interface
         public static void Initialize() { }
         public static void Initialize(string provider) { }
         public static bool IsProviderSupported(string provider) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use Initialize(string provider) instead.")]
         public static void SetDefaultProvider(string name) { }
     }
     public sealed partial class MonoTlsSettings

--- a/platforms/xamarin.mac/mscorlib.cs
+++ b/platforms/xamarin.mac/mscorlib.cs
@@ -11896,22 +11896,6 @@ namespace System.Runtime.InteropServices
         public ComAliasNameAttribute(string alias) { }
         public string Value { get { throw null; } }
     }
-    public partial class ComAwareEventInfo : System.Reflection.EventInfo
-    {
-        public ComAwareEventInfo(System.Type type, string eventName) { }
-        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
-        public override System.Type DeclaringType { get { throw null; } }
-        public override string Name { get { throw null; } }
-        public override System.Type ReflectedType { get { throw null; } }
-        public override void AddEventHandler(object target, System.Delegate handler) { }
-        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-        public override object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override void RemoveEventHandler(object target, System.Delegate handler) { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class ComCompatibleVersionAttribute : System.Attribute
     {
@@ -12434,6 +12418,7 @@ namespace System.Runtime.InteropServices
         public static object BindToMoniker(string monikerName) { throw null; }
         public static System.IntPtr BufferToBSTR(System.Array ptr, int slen) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
@@ -17552,7 +17537,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public IncrementalHash() { }
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }

--- a/platforms/xamarin.tvos/System.Core.cs
+++ b/platforms/xamarin.tvos/System.Core.cs
@@ -2262,6 +2262,25 @@ namespace System.Runtime.CompilerServices
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : System.Reflection.EventInfo
+    {
+        public ComAwareEventInfo(System.Type type, string eventName) { }
+        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
+        public override System.Type DeclaringType { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override System.Type ReflectedType { get { throw null; } }
+        public override void AddEventHandler(object target, System.Delegate handler) { }
+        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override void RemoveEventHandler(object target, System.Delegate handler) { }
+    }
+}
 namespace System.Security.Cryptography
 {
     public sealed partial class AesCng : System.Security.Cryptography.Aes

--- a/platforms/xamarin.tvos/System.Data.cs
+++ b/platforms/xamarin.tvos/System.Data.cs
@@ -2131,7 +2131,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/xamarin.tvos/System.Data.csproj
+++ b/platforms/xamarin.tvos/System.Data.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
     <ProjectReference Include="System.csproj" />
+    <ProjectReference Include="System.Transactions.csproj" />
     <ProjectReference Include="System.Xml.csproj" />
     <Compile Include="System.Data.cs" />
   </ItemGroup>

--- a/platforms/xamarin.tvos/System.Transactions.cs
+++ b/platforms/xamarin.tvos/System.Transactions.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Transactions
+{
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        public CommittableTransaction() { }
+        public CommittableTransaction(System.TimeSpan timeout) { }
+        public CommittableTransaction(System.Transactions.TransactionOptions options) { }
+        object System.IAsyncResult.AsyncState { get { throw null; } }
+        System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
+        bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
+        bool System.IAsyncResult.IsCompleted { get { throw null; } }
+        public System.IAsyncResult BeginCommit(System.AsyncCallback callback, object user_defined_state) { throw null; }
+        public void Commit() { }
+        public void EndCommit(System.IAsyncResult ar) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public enum DependentCloneOption
+    {
+        BlockCommitUntilComplete = 0,
+        RollbackIfNotComplete = 1,
+    }
+    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    {
+        internal DependentTransaction() { }
+        public void Complete() { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class Enlistment
+    {
+        internal Enlistment() { }
+        public void Done() { }
+    }
+    [System.FlagsAttribute]
+    public enum EnlistmentOptions
+    {
+        EnlistDuringPrepareRequired = 1,
+        None = 0,
+    }
+    public enum EnterpriseServicesInteropOption
+    {
+        Automatic = 1,
+        Full = 2,
+        None = 0,
+    }
+    public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
+    public partial interface IDtcTransaction
+    {
+        void Abort(System.IntPtr manager, int whatever, int whatever2);
+        void Commit(int whatever, int whatever2, int whatever3);
+        void GetTransactionInfo(System.IntPtr whatever);
+    }
+    public partial interface IEnlistmentNotification
+    {
+        void Commit(System.Transactions.Enlistment enlistment);
+        void InDoubt(System.Transactions.Enlistment enlistment);
+        void Prepare(System.Transactions.PreparingEnlistment preparingEnlistment);
+        void Rollback(System.Transactions.Enlistment enlistment);
+    }
+    public partial interface IPromotableSinglePhaseNotification : System.Transactions.ITransactionPromoter
+    {
+        void Initialize();
+        void Rollback(System.Transactions.SinglePhaseEnlistment enlistment);
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public partial interface ISimpleTransactionSuperior : System.Transactions.ITransactionPromoter
+    {
+        void Rollback();
+    }
+    public partial interface ISinglePhaseNotification : System.Transactions.IEnlistmentNotification
+    {
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public enum IsolationLevel
+    {
+        Chaos = 5,
+        ReadCommitted = 2,
+        ReadUncommitted = 3,
+        RepeatableRead = 1,
+        Serializable = 0,
+        Snapshot = 4,
+        Unspecified = 6,
+    }
+    public partial interface ITransactionPromoter
+    {
+        byte[] Promote();
+    }
+    public partial class PreparingEnlistment : System.Transactions.Enlistment
+    {
+        internal PreparingEnlistment() { }
+        public void ForceRollback() { }
+        public void ForceRollback(System.Exception ex) { }
+        public void Prepared() { }
+        public byte[] RecoveryInformation() { throw null; }
+    }
+    public partial class SinglePhaseEnlistment : System.Transactions.Enlistment
+    {
+        internal SinglePhaseEnlistment() { }
+        public void Aborted() { }
+        public void Aborted(System.Exception e) { }
+        public void Committed() { }
+        public void InDoubt() { }
+        public void InDoubt(System.Exception e) { }
+    }
+    public sealed partial class SubordinateTransaction : System.Transactions.Transaction
+    {
+        public SubordinateTransaction(System.Transactions.IsolationLevel level, System.Transactions.ISimpleTransactionSuperior superior) { }
+    }
+    public partial class Transaction : System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        internal Transaction() { }
+        public static System.Transactions.Transaction Current { get { throw null; } set { } }
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
+        public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
+        public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
+        protected System.IAsyncResult BeginCommitInternal(System.AsyncCallback callback) { throw null; }
+        public System.Transactions.Transaction Clone() { throw null; }
+        public System.Transactions.DependentTransaction DependentClone(System.Transactions.DependentCloneOption option) { throw null; }
+        public void Dispose() { }
+        protected void EndCommitInternal(System.IAsyncResult ar) { }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public bool EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification notification) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public static bool operator !=(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public void Rollback() { }
+        public void Rollback(System.Exception ex) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TransactionAbortedException : System.Transactions.TransactionException
+    {
+        public TransactionAbortedException() { }
+        protected TransactionAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionAbortedException(string message) { }
+        public TransactionAbortedException(string message, System.Exception innerException) { }
+    }
+    public delegate void TransactionCompletedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public partial class TransactionEventArgs : System.EventArgs
+    {
+        public TransactionEventArgs() { }
+        public System.Transactions.Transaction Transaction { get { throw null; } }
+    }
+    public partial class TransactionException : System.SystemException
+    {
+        protected TransactionException() { }
+        protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionException(string message) { }
+        public TransactionException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInDoubtException : System.Transactions.TransactionException
+    {
+        protected TransactionInDoubtException() { }
+        protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionInDoubtException(string message) { }
+        public TransactionInDoubtException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInformation
+    {
+        internal TransactionInformation() { }
+        public System.DateTime CreationTime { get { throw null; } }
+        public System.Guid DistributedIdentifier { get { throw null; } }
+        public string LocalIdentifier { get { throw null; } }
+        public System.Transactions.TransactionStatus Status { get { throw null; } }
+    }
+    public static partial class TransactionInterop
+    {
+        public static System.Transactions.IDtcTransaction GetDtcTransaction(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetExportCookie(System.Transactions.Transaction transaction, byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromDtcTransaction(System.Transactions.IDtcTransaction dtc) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromExportCookie(byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromTransmitterPropagationToken(byte[] token) { throw null; }
+        public static byte[] GetTransmitterPropagationToken(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetWhereabouts() { throw null; }
+    }
+    public static partial class TransactionManager
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.Transactions.HostCurrentTransactionCallback HostCurrentCallback { get { throw null; } set { } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static event System.Transactions.TransactionStartedEventHandler DistributedTransactionStarted { add { } remove { } }
+        public static void RecoveryComplete(System.Guid manager) { }
+        public static System.Transactions.Enlistment Reenlist(System.Guid manager, byte[] recoveryInfo, System.Transactions.IEnlistmentNotification notification) { throw null; }
+    }
+    public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
+    {
+        protected TransactionManagerCommunicationException() { }
+        protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionManagerCommunicationException(string message) { }
+        public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct TransactionOptions
+    {
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
+        public System.TimeSpan Timeout { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+    }
+    public partial class TransactionPromotionException : System.Transactions.TransactionException
+    {
+        protected TransactionPromotionException() { }
+        protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionPromotionException(string message) { }
+        public TransactionPromotionException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class TransactionScope : System.IDisposable
+    {
+        public TransactionScope() { }
+        public TransactionScope(System.Transactions.Transaction transaction) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public void Complete() { }
+        public void Dispose() { }
+    }
+    public enum TransactionScopeAsyncFlowOption
+    {
+        Enabled = 1,
+        Suppress = 0,
+    }
+    public enum TransactionScopeOption
+    {
+        Required = 0,
+        RequiresNew = 1,
+        Suppress = 2,
+    }
+    public delegate void TransactionStartedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public enum TransactionStatus
+    {
+        Aborted = 2,
+        Active = 0,
+        Committed = 1,
+        InDoubt = 3,
+    }
+}

--- a/platforms/xamarin.tvos/System.Transactions.csproj
+++ b/platforms/xamarin.tvos/System.Transactions.csproj
@@ -10,10 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
-    <ProjectReference Include="System.csproj" />
-    <ProjectReference Include="System.Transactions.csproj" />
-    <ProjectReference Include="System.Xml.csproj" />
-    <Compile Include="System.Data.cs" />
+    <Compile Include="System.Transactions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/platforms/xamarin.tvos/System.cs
+++ b/platforms/xamarin.tvos/System.cs
@@ -479,7 +479,7 @@ namespace Mono.Security.Interface
         public static bool IsInitialized { get { throw null; } }
         public static System.Net.HttpListener CreateHttpListener(System.Security.Cryptography.X509Certificates.X509Certificate certificate, Mono.Security.Interface.MonoTlsProvider provider=null, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
         public static System.Net.HttpWebRequest CreateHttpsRequest(System.Uri requestUri, Mono.Security.Interface.MonoTlsProvider provider, Mono.Security.Interface.MonoTlsSettings settings=null) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use GetProvider() instead.")]
         public static Mono.Security.Interface.MonoTlsProvider GetDefaultProvider() { throw null; }
         public static Mono.Security.Interface.IMonoSslStream GetMonoSslStream(System.Net.Security.SslStream stream) { throw null; }
         public static Mono.Security.Interface.MonoTlsProvider GetProvider() { throw null; }
@@ -487,7 +487,7 @@ namespace Mono.Security.Interface
         public static void Initialize() { }
         public static void Initialize(string provider) { }
         public static bool IsProviderSupported(string provider) { throw null; }
-        [System.ObsoleteAttribute]
+        [System.ObsoleteAttribute("Use Initialize(string provider) instead.")]
         public static void SetDefaultProvider(string name) { }
     }
     public sealed partial class MonoTlsSettings

--- a/platforms/xamarin.tvos/mscorlib.cs
+++ b/platforms/xamarin.tvos/mscorlib.cs
@@ -11186,22 +11186,6 @@ namespace System.Runtime.InteropServices
         public ComAliasNameAttribute(string alias) { }
         public string Value { get { throw null; } }
     }
-    public partial class ComAwareEventInfo : System.Reflection.EventInfo
-    {
-        public ComAwareEventInfo(System.Type type, string eventName) { }
-        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
-        public override System.Type DeclaringType { get { throw null; } }
-        public override string Name { get { throw null; } }
-        public override System.Type ReflectedType { get { throw null; } }
-        public override void AddEventHandler(object target, System.Delegate handler) { }
-        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-        public override object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override void RemoveEventHandler(object target, System.Delegate handler) { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class ComCompatibleVersionAttribute : System.Attribute
     {
@@ -11690,6 +11674,7 @@ namespace System.Runtime.InteropServices
         public static object BindToMoniker(string monikerName) { throw null; }
         public static System.IntPtr BufferToBSTR(System.Array ptr, int slen) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
@@ -16562,7 +16547,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public IncrementalHash() { }
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }

--- a/platforms/xamarin.watchos/System.Core.cs
+++ b/platforms/xamarin.watchos/System.Core.cs
@@ -2262,6 +2262,25 @@ namespace System.Runtime.CompilerServices
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
 }
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : System.Reflection.EventInfo
+    {
+        public ComAwareEventInfo(System.Type type, string eventName) { }
+        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
+        public override System.Type DeclaringType { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override System.Type ReflectedType { get { throw null; } }
+        public override void AddEventHandler(object target, System.Delegate handler) { }
+        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override void RemoveEventHandler(object target, System.Delegate handler) { }
+    }
+}
 namespace System.Security.Cryptography
 {
     public sealed partial class AesCng : System.Security.Cryptography.Aes

--- a/platforms/xamarin.watchos/System.Data.cs
+++ b/platforms/xamarin.watchos/System.Data.cs
@@ -2131,7 +2131,7 @@ namespace System.Data.Common
         public abstract void Close();
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
-//TRANSACTIONS        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }

--- a/platforms/xamarin.watchos/System.Data.csproj
+++ b/platforms/xamarin.watchos/System.Data.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
     <ProjectReference Include="System.csproj" />
+    <ProjectReference Include="System.Transactions.csproj" />
     <ProjectReference Include="System.Xml.csproj" />
     <Compile Include="System.Data.cs" />
   </ItemGroup>

--- a/platforms/xamarin.watchos/System.Transactions.cs
+++ b/platforms/xamarin.watchos/System.Transactions.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Transactions
+{
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        public CommittableTransaction() { }
+        public CommittableTransaction(System.TimeSpan timeout) { }
+        public CommittableTransaction(System.Transactions.TransactionOptions options) { }
+        object System.IAsyncResult.AsyncState { get { throw null; } }
+        System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
+        bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
+        bool System.IAsyncResult.IsCompleted { get { throw null; } }
+        public System.IAsyncResult BeginCommit(System.AsyncCallback callback, object user_defined_state) { throw null; }
+        public void Commit() { }
+        public void EndCommit(System.IAsyncResult ar) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public enum DependentCloneOption
+    {
+        BlockCommitUntilComplete = 0,
+        RollbackIfNotComplete = 1,
+    }
+    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    {
+        internal DependentTransaction() { }
+        public void Complete() { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class Enlistment
+    {
+        internal Enlistment() { }
+        public void Done() { }
+    }
+    [System.FlagsAttribute]
+    public enum EnlistmentOptions
+    {
+        EnlistDuringPrepareRequired = 1,
+        None = 0,
+    }
+    public enum EnterpriseServicesInteropOption
+    {
+        Automatic = 1,
+        Full = 2,
+        None = 0,
+    }
+    public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
+    public partial interface IDtcTransaction
+    {
+        void Abort(System.IntPtr manager, int whatever, int whatever2);
+        void Commit(int whatever, int whatever2, int whatever3);
+        void GetTransactionInfo(System.IntPtr whatever);
+    }
+    public partial interface IEnlistmentNotification
+    {
+        void Commit(System.Transactions.Enlistment enlistment);
+        void InDoubt(System.Transactions.Enlistment enlistment);
+        void Prepare(System.Transactions.PreparingEnlistment preparingEnlistment);
+        void Rollback(System.Transactions.Enlistment enlistment);
+    }
+    public partial interface IPromotableSinglePhaseNotification : System.Transactions.ITransactionPromoter
+    {
+        void Initialize();
+        void Rollback(System.Transactions.SinglePhaseEnlistment enlistment);
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public partial interface ISimpleTransactionSuperior : System.Transactions.ITransactionPromoter
+    {
+        void Rollback();
+    }
+    public partial interface ISinglePhaseNotification : System.Transactions.IEnlistmentNotification
+    {
+        void SinglePhaseCommit(System.Transactions.SinglePhaseEnlistment enlistment);
+    }
+    public enum IsolationLevel
+    {
+        Chaos = 5,
+        ReadCommitted = 2,
+        ReadUncommitted = 3,
+        RepeatableRead = 1,
+        Serializable = 0,
+        Snapshot = 4,
+        Unspecified = 6,
+    }
+    public partial interface ITransactionPromoter
+    {
+        byte[] Promote();
+    }
+    public partial class PreparingEnlistment : System.Transactions.Enlistment
+    {
+        internal PreparingEnlistment() { }
+        public void ForceRollback() { }
+        public void ForceRollback(System.Exception ex) { }
+        public void Prepared() { }
+        public byte[] RecoveryInformation() { throw null; }
+    }
+    public partial class SinglePhaseEnlistment : System.Transactions.Enlistment
+    {
+        internal SinglePhaseEnlistment() { }
+        public void Aborted() { }
+        public void Aborted(System.Exception e) { }
+        public void Committed() { }
+        public void InDoubt() { }
+        public void InDoubt(System.Exception e) { }
+    }
+    public sealed partial class SubordinateTransaction : System.Transactions.Transaction
+    {
+        public SubordinateTransaction(System.Transactions.IsolationLevel level, System.Transactions.ISimpleTransactionSuperior superior) { }
+    }
+    public partial class Transaction : System.IDisposable, System.Runtime.Serialization.ISerializable
+    {
+        internal Transaction() { }
+        public static System.Transactions.Transaction Current { get { throw null; } set { } }
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
+        public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
+        public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
+        protected System.IAsyncResult BeginCommitInternal(System.AsyncCallback callback) { throw null; }
+        public System.Transactions.Transaction Clone() { throw null; }
+        public System.Transactions.DependentTransaction DependentClone(System.Transactions.DependentCloneOption option) { throw null; }
+        public void Dispose() { }
+        protected void EndCommitInternal(System.IAsyncResult ar) { }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistDurable(System.Guid manager, System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public bool EnlistPromotableSinglePhase(System.Transactions.IPromotableSinglePhaseNotification notification) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.IEnlistmentNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public System.Transactions.Enlistment EnlistVolatile(System.Transactions.ISinglePhaseNotification notification, System.Transactions.EnlistmentOptions options) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public static bool operator !=(System.Transactions.Transaction x, System.Transactions.Transaction y) { throw null; }
+        public void Rollback() { }
+        public void Rollback(System.Exception ex) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TransactionAbortedException : System.Transactions.TransactionException
+    {
+        public TransactionAbortedException() { }
+        protected TransactionAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionAbortedException(string message) { }
+        public TransactionAbortedException(string message, System.Exception innerException) { }
+    }
+    public delegate void TransactionCompletedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public partial class TransactionEventArgs : System.EventArgs
+    {
+        public TransactionEventArgs() { }
+        public System.Transactions.Transaction Transaction { get { throw null; } }
+    }
+    public partial class TransactionException : System.SystemException
+    {
+        protected TransactionException() { }
+        protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionException(string message) { }
+        public TransactionException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInDoubtException : System.Transactions.TransactionException
+    {
+        protected TransactionInDoubtException() { }
+        protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionInDoubtException(string message) { }
+        public TransactionInDoubtException(string message, System.Exception innerException) { }
+    }
+    public partial class TransactionInformation
+    {
+        internal TransactionInformation() { }
+        public System.DateTime CreationTime { get { throw null; } }
+        public System.Guid DistributedIdentifier { get { throw null; } }
+        public string LocalIdentifier { get { throw null; } }
+        public System.Transactions.TransactionStatus Status { get { throw null; } }
+    }
+    public static partial class TransactionInterop
+    {
+        public static System.Transactions.IDtcTransaction GetDtcTransaction(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetExportCookie(System.Transactions.Transaction transaction, byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromDtcTransaction(System.Transactions.IDtcTransaction dtc) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromExportCookie(byte[] exportCookie) { throw null; }
+        public static System.Transactions.Transaction GetTransactionFromTransmitterPropagationToken(byte[] token) { throw null; }
+        public static byte[] GetTransmitterPropagationToken(System.Transactions.Transaction transaction) { throw null; }
+        public static byte[] GetWhereabouts() { throw null; }
+    }
+    public static partial class TransactionManager
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.Transactions.HostCurrentTransactionCallback HostCurrentCallback { get { throw null; } set { } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static event System.Transactions.TransactionStartedEventHandler DistributedTransactionStarted { add { } remove { } }
+        public static void RecoveryComplete(System.Guid manager) { }
+        public static System.Transactions.Enlistment Reenlist(System.Guid manager, byte[] recoveryInfo, System.Transactions.IEnlistmentNotification notification) { throw null; }
+    }
+    public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
+    {
+        protected TransactionManagerCommunicationException() { }
+        protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionManagerCommunicationException(string message) { }
+        public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct TransactionOptions
+    {
+        public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
+        public System.TimeSpan Timeout { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+    }
+    public partial class TransactionPromotionException : System.Transactions.TransactionException
+    {
+        protected TransactionPromotionException() { }
+        protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TransactionPromotionException(string message) { }
+        public TransactionPromotionException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class TransactionScope : System.IDisposable
+    {
+        public TransactionScope() { }
+        public TransactionScope(System.Transactions.Transaction transaction) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.Transaction transaction, System.TimeSpan timeout, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.TimeSpan timeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.Transactions.TransactionOptions options, System.Transactions.EnterpriseServicesInteropOption opt) { }
+        public TransactionScope(System.Transactions.TransactionScopeOption option, System.Transactions.TransactionScopeAsyncFlowOption asyncFlow) { }
+        public void Complete() { }
+        public void Dispose() { }
+    }
+    public enum TransactionScopeAsyncFlowOption
+    {
+        Enabled = 1,
+        Suppress = 0,
+    }
+    public enum TransactionScopeOption
+    {
+        Required = 0,
+        RequiresNew = 1,
+        Suppress = 2,
+    }
+    public delegate void TransactionStartedEventHandler(object o, System.Transactions.TransactionEventArgs e);
+    public enum TransactionStatus
+    {
+        Aborted = 2,
+        Active = 0,
+        Committed = 1,
+        InDoubt = 3,
+    }
+}

--- a/platforms/xamarin.watchos/System.Transactions.csproj
+++ b/platforms/xamarin.watchos/System.Transactions.csproj
@@ -10,10 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="mscorlib.csproj" />
-    <ProjectReference Include="System.csproj" />
-    <ProjectReference Include="System.Transactions.csproj" />
-    <ProjectReference Include="System.Xml.csproj" />
-    <Compile Include="System.Data.cs" />
+    <Compile Include="System.Transactions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/platforms/xamarin.watchos/mscorlib.cs
+++ b/platforms/xamarin.watchos/mscorlib.cs
@@ -11186,22 +11186,6 @@ namespace System.Runtime.InteropServices
         public ComAliasNameAttribute(string alias) { }
         public string Value { get { throw null; } }
     }
-    public partial class ComAwareEventInfo : System.Reflection.EventInfo
-    {
-        public ComAwareEventInfo(System.Type type, string eventName) { }
-        public override System.Reflection.EventAttributes Attributes { get { throw null; } }
-        public override System.Type DeclaringType { get { throw null; } }
-        public override string Name { get { throw null; } }
-        public override System.Type ReflectedType { get { throw null; } }
-        public override void AddEventHandler(object target, System.Delegate handler) { }
-        public override System.Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-        public override object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-        public override System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override void RemoveEventHandler(object target, System.Delegate handler) { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class ComCompatibleVersionAttribute : System.Attribute
     {
@@ -11690,6 +11674,7 @@ namespace System.Runtime.InteropServices
         public static object BindToMoniker(string monikerName) { throw null; }
         public static System.IntPtr BufferToBSTR(System.Array ptr, int slen) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
@@ -16562,7 +16547,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public IncrementalHash() { }
+        internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }


### PR DESCRIPTION
Generates API reference for System.Transactions.dll for all Xamarin platforms.

The API compat shows some differences that we need to fix, the current revision in this PR is generated from our latest public C9 preview. I'll make the changes in Mono and update this repo once a new preview is out.

See #168 