### PR TITLE
Fix some unix build issues.

### DIFF
--- a/build-managed.sh
+++ b/build-managed.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-usage()
-{
-    echo "Usage: call ./build.sh"
-    echo
-}
-
-
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
-
-$__scriptpath/run.sh build-managed 
+$__scriptpath/run.sh build-managed $@
 exit $?

--- a/build.sh
+++ b/build.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 
-usage()
-{
-    echo
-    echo "Use this script only for generic build instructions that apply for both native builds and managed builds."
-    echo
-}
-
-if [ "$1" == "-?" ]; then
-    usage
-fi
-
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
-
-"$__scriptpath/build-managed.sh"
-
-if [ $? -ne 0 ];then
-   exit 1
-fi
+"$__scriptpath/build-managed.sh" $@
+exit $?

--- a/dir.targets
+++ b/dir.targets
@@ -61,5 +61,6 @@
   <PropertyGroup Condition="$(AssemblyOriginatorKeyFile.Contains('Open.snk'))">
     <StrongNameSig />
     <DelaySign>false</DelaySign>
-  </PropertyGroup> 
+    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+  </PropertyGroup>
 </Project>

--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\netstandard.csproj" />
-    <ProjectReference Include="..\tools\NETStandard.tools.builds" />
+    <ProjectReference Include="..\tools\NETStandard.Tools.builds" />
     <ProjectReference Include="shims\netstandard\dir.builds" />
     <ProjectReference Include="shims\netfx\dir.builds" />
     <ProjectReference Include="..\src\netstandard.csproj">


### PR DESCRIPTION
- Flow arguments from build.sh and build-managed.sh to run.sh (so you
  can pass -Release and get a release build).
- Public sign instead of full sign when using the Open key
  on *NIX (where csc does not yet support full signing).
- Fix casing issue in a .builds file.