### PR TITLE
Fix supported framework version

### DIFF
--- a/docs/versions/netstandard1.5.md
+++ b/docs/versions/netstandard1.5.md
@@ -8,7 +8,7 @@
 ## Platform Support
 
 * .NET Core 1.0
-* .NET Framework 4.6.1
+* .NET Framework 4.6.2
 * Mono 4.6
 * Xamarin.iOS 10.0
 * Xamarin.Android 7.0


### PR DESCRIPTION
After spending 2 hours thinking my vs 2017 or solution was busted... I suspect this doc is wrong.. or the nuget config is wrong

[Nuget Config Showing .Net Framework to Standard Version Mapping](https://github.com/NuGet/NuGet.Client/blob/c1add033fb9f5ec05c6032aeb3f1ad29522fbb63/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs#L402-L413)