### PR TITLE
Fix capitalization issue breaking build on Linux

### DIFF
--- a/netstandard/src/netstandard.csproj
+++ b/netstandard/src/netstandard.csproj
@@ -87,7 +87,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_GenAPICmd>$(ToolHostCmd) "$(ToolsDir)GenApi.exe"</_GenAPICmd>
+      <_GenAPICmd>$(ToolHostCmd) "$(ToolsDir)GenAPI.exe"</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -assembly:"$(_ReferenceAssembly)"</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -writer:TypeForwards</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -out:"$(_TypeForwardsOutputPath)"</_GenAPICmd>


### PR DESCRIPTION
The file is named `GenAPI.exe`. On case insensitive file systems it works if called as `GenApi.exe`. On linux (and other operating systems) where capitalization matters, the name mismatch causes the build steps using this file to fail. This breaks the build.

The build breakage was introduced by e8a2b897.

Without this fix, the build fails on Linux:

    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/net461/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.net461.txt" exited with code 1.
    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/xamarin.tvos/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.xamarin.tvos.txt" exited with code 1.
    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/xamarin.ios/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.xamarin.ios.txt" exited with code 1.
    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/xamarin.android/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.xamarin.android.txt" exited with code 1.
    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/xamarin.watchos/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.xamarin.watchos.txt" exited with code 1.
    /home/omajid/standard/netstandard/src/netstandard.csproj(97,5): error MSB3073: The command ""/home/omajid/standard/Tools/dotnetcli/dotnet" "/home/omajid/standard/Tools/GenApi.exe" -assembly:"/home/omajid/standard/bin/ref/netstandard/2.0.0
    .0/netstandard.dll" -writer:TypeForwards -out:"/home/omajid/standard/bin/obj/AnyOS.AnyCPU.Debug/netstandard/xamarin.mac/netstandard.forwards.cs" -excludeApiList:GenApi.exclude.xamarin.mac.txt" exited with code 1.

Would it be possible to add some sort of CI building this repo on Linux?