### PR TITLE
Remove ReferenceAssemblyAttribute and 0x70 AssemblyFlag bit from shims

### DIFF
--- a/netstandard/pkg/shims/dir.targets
+++ b/netstandard/pkg/shims/dir.targets
@@ -15,5 +15,20 @@
     <AssemblyOriginatorKeyFile Condition="'$(UseXamarinProductsKey)' == 'true'">$(MSBuildThisFileDirectory)xamarin-products.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <!--
+    We want to use these shims at runtime as well in some cases so we need to not
+    have the ReferenceAssemblyAttribute or the AssemblyFlags 0x70 bit set otherwise
+    the runtime will block loading them.
+  -->
+  <Target Name="ClearReferenceAssemblyBits" BeforeTargets="GenerateAssemblyInfo">
+    <!--
+      Removes all the lines added before GenerateAssemblyInfo is called. In particular clears the
+      lines added by ReferenceAssemblies.targets.
+    -->
+    <ItemGroup>
+      <AssemblyInfoLines Remove="@(AssemblyInfoLines)" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
We want to use the shims at runtime as well and the loader will block
them if they have that runtime bit set on them so we need to clear that
bit from them.

cc @tarekgh @ericstj