### PR TITLE
Make trimming work for shared framework apps

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/Trimming/TrimFiles.cs
+++ b/Microsoft.Packaging.Tools/tasks/Trimming/TrimFiles.cs
@@ -55,7 +55,6 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <summary>
         /// RuntimeIdentifier to use when determining package dependencies.
         /// </summary>
-        [Required]
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Don't require RID to be specified.

/cc @weshaggard @petermarcu @terrajobst