### PR TITLE
Update file version to be 4.6 which matches the seed assemblies

### DIFF
--- a/netstandard/pkg/shims/dir.targets
+++ b/netstandard/pkg/shims/dir.targets
@@ -16,6 +16,16 @@
   </PropertyGroup>
 
   <!--
+    These shims need to have a higher file version then the last ones we shipped to ensure they win
+    the conflict resolution so setting major/minor to match what was shipped before. The patch version
+    is computed based on a date seed so it should always be higher then what we shipped previously.
+  -->
+  <PropertyGroup>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>6</MinorVersion>
+  </PropertyGroup>
+
+  <!--
     We want to use these shims at runtime as well in some cases so we need to not
     have the ReferenceAssemblyAttribute or the AssemblyFlags 0x70 bit set otherwise
     the runtime will block loading them.


### PR DESCRIPTION
We need the shim file versions to be higher then the seed assemblies
we are using in order for them to win during conflict resolution. The
seeds were in the 4.6.patch versioning where patch version is using a
date seed that we are still using so it will always be higher.

Fixes https://github.com/dotnet/standard/issues/229. 

cc @ericstj 