### PR TITLE
Trim meta-packages by default

### DIFF
--- a/Microsoft.Packaging.Tools/docs/trimming.md
+++ b/Microsoft.Packaging.Tools/docs/trimming.md
@@ -52,11 +52,11 @@ In your project (*.csproj* file) make the following change.
 <ItemGroup>
 ```
 
-- Specify TrimmablePackages to indicate that the `System.Composition` meta-package should be considered trimmable and only the files in its closure that are actually used should be included.
+- Specify TrimmablePackages to indicate that the `NuGet.Client` package should be considered trimmable and only the files in its closure that are actually used should be included.
 
 ```xml
 <ItemGroup>
-  <TrimmablePackages Include="System.Composition" />
+  <TrimmablePackages Include="NuGet.Client" />
 <ItemGroup>
 ```
 

--- a/Microsoft.Packaging.Tools/docs/trimming.md
+++ b/Microsoft.Packaging.Tools/docs/trimming.md
@@ -39,8 +39,9 @@ In your project (*.csproj* file) make the following change.
 `@(TrimFilesRootPackages)` -  Additional *root* packages to consider part of the application.  See [roots](#roots).  
 `@(TrimmableFiles)` - Files which should be trimmed from the application.  See [trimmable](#trimmable).  
 `@(TrimmablePackages)` - Packages which should be trimmed from the application.  See [trimmable](#trimmable).  
-`$(TrimFilesPreferNativeImages)` - Prefer a file with the `.ni.dll` extension over a file with the `.dll` extension.  `.ni.dll` files are native images and significantly larger than a managed assembly but will load faster since they don't need to be JIT compiled.
-`$(RootPackageReference)` - Set to `false` to indicate that `PackageReferences` should not be considered as *[roots](roots)*.
+`$(TrimFilesPreferNativeImages)` - Prefer a file with the `.ni.dll` extension over a file with the `.dll` extension.  `.ni.dll` files are native images and significantly larger than a managed assembly but will load faster since they don't need to be JIT compiled.  Default is `false`.
+`$(RootPackageReference)` - Set to `false` to indicate that `PackageReferences` should not be considered as *[roots](roots)*.  Default is `true`.
+`$(TreatMetaPackagesAsTrimmable)` - When set to `true` indicates that meta-packages (packages without any file assets) should be treated as *[trimmable](#trimmable)*.  Default is `true`.
 
 **Examples:**
 - Specify TrimFilesRootFiles to include file `System.IO.Pipes.dll`.

--- a/Microsoft.Packaging.Tools/tasks/Trimming/NuGetPackageNode.cs
+++ b/Microsoft.Packaging.Tools/tasks/Trimming/NuGetPackageNode.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.Build.Tasks
         public bool IsIncluded { get; set; }
         public string Version { get; }
         public bool IsProject { get; }
+        public bool IsMetaPackage { get { return Files.Count == 0; } }
         public IEnumerable<NuGetPackageNode> Dependencies { get { return _dependencies; } }
         public IList<FileNode> Files { get; } = new List<FileNode>();
 

--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -3,6 +3,10 @@
 
   <UsingTask TaskName="TrimFiles" AssemblyFile="$(MicrosoftPackagingToolsTaskDirectory)Microsoft.Packaging.Tools.Tasks.dll" />
 
+  <PropertyGroup>
+    <TreatMetaPackagesAsTrimmable Condition="'$(TreatMetaPackagesAsTrimmable)' == ''">true</TreatMetaPackagesAsTrimmable>
+  </PropertyGroup>
+  
   <Target Name="_determineTrimPackageInputs">
     <ItemGroup Condition="'$(RootPackageReference)' != 'true'">
       <TrimFilesRootPackages Include="@(PackageReference)"/>
@@ -38,7 +42,8 @@
                RuntimeIdentifier="$(RuntimeIdentifier)"
                RuntimeItems="@(ReferenceCopyLocalPaths)"
                OtherRuntimeItems="@(_trimOtherRuntimeItems)"
-               PreferNativeImages="$(TrimFilesPreferNativeImages)">
+               PreferNativeImages="$(TrimFilesPreferNativeImages)"
+               TreatMetaPackagesAsTrimmable="$(TreatMetaPackagesAsTrimmable)">
       <Output ItemName="_ReferenceCopyLocalPathsAfterTrimming" TaskParameter="RuntimeItemsAfterTrimming" />
       <Output ItemName="_ConflictPackageFiles" TaskParameter="TrimmedItems" />
     </TrimFiles>
@@ -61,7 +66,8 @@
                TargetFramework="$(TargetFrameworkMoniker)"
                RuntimeIdentifier="$(RuntimeIdentifier)"
                RuntimeItems="@(ResolvedAssembliesToPublish)"
-               PreferNativeImages="$(TrimFilesPreferNativeImages)" >
+               PreferNativeImages="$(TrimFilesPreferNativeImages)"
+               TreatMetaPackagesAsTrimmable="$(TreatMetaPackagesAsTrimmable)">
       <Output ItemName="_ResolvedAssembliesToPublishAfterTrimming" TaskParameter="RuntimeItemsAfterTrimming" />
       <Output ItemName="_PublishConflictPackageFiles" TaskParameter="TrimmedItems" />
     </TrimFiles>


### PR DESCRIPTION
This makes trimming identify meta-packages as packages with no files.

We will treat meta-packages as trimmable unless the project sets
TreatMetaPackagesAsTrimmable=false.

Fixes #231 

/cc @weshaggard @Petermarcu @terrajobst @livarcocc 