### PR TITLE
Ensure correct rank for non-preferred packages

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/PackageRank.cs
+++ b/Microsoft.Packaging.Tools/tasks/PackageRank.cs
@@ -37,14 +37,13 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <returns>rank of package</returns>
         public int GetPackageRank(string packageId)
         {
-            int rank = int.MaxValue;
-
-            if (packageId != null)
+            int rank;
+            if (packageId != null && packageRanks.TryGetValue(packageId, out rank))
             {
-                packageRanks.TryGetValue(packageId, out rank);
+                return rank;
             }
 
-            return rank;
+            return int.MaxValue;
         }
     }
 }


### PR DESCRIPTION
Previously we would return 0 incorrectly since that was defaulted by
TryGetValue.  Make sure we return the sentinel value (max) when the
package is not preferred.

/cc @weshaggard @billwert