### PR TITLE
Ensure publish trimming sees project references

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -56,7 +56,7 @@
 
   <Target Name="TrimFilesOnPublish"
           DependsOnTargets="_determineTrimPackageInputs"
-          AfterTargets="HandlePublishFileConflicts">
+          BeforeTargets="ComputeFilesToPublish">
 
     <TrimFiles RootFiles="@(IntermediateAssembly);@(TrimFilesRootFiles)"
                RootPackages="@(TrimFilesRootPackages)"


### PR DESCRIPTION
We were running TrimFilesOnPublish too early, before the SDK targets had
finished building out the ResolvedAssembliesToPublish item.

/cc @eerhardt 

Fixes #264 