### PR TITLE
Add IsSelfContained parameter to ResolvePublishAssemblies.

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
@@ -48,7 +48,8 @@
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
+                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)"
+                              IsSelfContained="$(SelfContained)">
 
       <Output TaskParameter="AssembliesToPublish" ItemName="_LockFileAssemblies" />
 


### PR DESCRIPTION
This is necessary because of https://github.com/dotnet/sdk/pull/1053

@ericstj @weshaggard 

@dsplaisted - I know you are working on moving this logic to the dotnet/sdk.  Giving you a heads up in case this logic is still duplicated in your port.