### PR TITLE
Follow type forwards

### DIFF
--- a/Microsoft.Packaging.Tools/docs/trimming.md
+++ b/Microsoft.Packaging.Tools/docs/trimming.md
@@ -41,6 +41,7 @@ In your project (*.csproj* file) make the following change.
 `@(TrimmablePackages)` - Packages which should be trimmed from the application.  See [trimmable](#trimmable).  
 `$(TrimFilesPreferNativeImages)` - Prefer a file with the `.ni.dll` extension over a file with the `.dll` extension.  `.ni.dll` files are native images and significantly larger than a managed assembly but will load faster since they don't need to be JIT compiled.  Default is `false`.
 `$(RootPackageReference)` - Set to `false` to indicate that `PackageReferences` should not be considered as *[roots](roots)*.  Default is `true`.
+`$(RootProjectReference)` - Set to `false` to indicate that `ProjectReferences` should not be considered as *[roots](roots)*.  Default is `true`.
 `$(TreatMetaPackagesAsTrimmable)` - When set to `true` indicates that meta-packages (packages without any file assets) should be treated as *[trimmable](#trimmable)*.  Default is `true`.
 
 **Examples:**

--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -8,11 +8,11 @@
   </PropertyGroup>
   
   <Target Name="_determineTrimPackageInputs">
-    <ItemGroup Condition="'$(RootPackageReference)' != 'true'">
+    <ItemGroup Condition="'$(RootPackageReference)' != 'false'">
       <TrimFilesRootPackages Include="@(PackageReference)"/>
     </ItemGroup>
     
-    <ItemGroup Condition="'$(RootProjectReference)' != 'true'">
+    <ItemGroup Condition="'$(RootProjectReference)' != 'false'">
       <TrimFilesRootFiles Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference'"/>
     </ItemGroup>
 

--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -11,6 +11,10 @@
     <ItemGroup Condition="'$(RootPackageReference)' != 'true'">
       <TrimFilesRootPackages Include="@(PackageReference)"/>
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(RootProjectReference)' != 'true'">
+      <TrimFilesRootFiles Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference'"/>
+    </ItemGroup>
 
     <!-- todo: move this stuff to NETCore.App package -->
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">


### PR DESCRIPTION
/cc @Petermarcu @weshaggard @Thealexbarney 

Fixes #284 
Fixes #265 

Prior to this change an app would jump up to >20MB as soon as you referenced a netstandard2.0 library.  Now we see normal incremental change when doing this.