### PR TITLE
Add support for ForcedPackages

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
@@ -61,6 +61,7 @@
                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
                                 OtherRuntimeItems="@(_LockFileAssemblies)"
                                 PlatformManifests="@(PackageConflictPlatformManifests)"
+                                ForcedPackages="$(PackageConflictForcedPackages)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
@@ -96,6 +97,7 @@
   <Target Name="HandlePublishFileConflicts" AfterTargets="$(HandlePublishFileConflictsAfter)">
     <HandlePackageFileConflicts ReferenceCopyLocalPaths="@(ResolvedAssembliesToPublish)"
                                 PlatformManifests="@(PackageConflictPlatformManifests)"
+                                ForcedPackages="$(PackageConflictForcedPackages)"
                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ResolvedAssembliesToPublishWithoutConflicts" />
       <Output TaskParameter="Conflicts" ItemName="_PublishConflictPackageFiles" />


### PR DESCRIPTION
In some cases folks may want to force us to choose a particular package
when a conflict exists.  This permits that.

By setting the PackageConflictForcedPackages to an ordered list of
package Ids, this list will be preferred, in order, over any other
conflict resolution check (assembly version, file version, preferred
package, platform package).

Fixes #247 

/cc @terrajobst @weshaggard @dsplaisted 