### PR TITLE
Trim NETCoreApp 1.x runtime

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -22,10 +22,10 @@
       <TrimFilesRootFiles Include="hostpolicy.dll;libhostpolicy.dylib;libhostpolicy.so" />
 
       <!-- treat platform packages as trimmable -->
-      <TrimmablePackages Include="$(PackageConflictPreferredPackages)" />
+      <TrimmablePackages Condition="'$(DontTrimNETCoreAppRuntime)' != 'true'" Include="$(PackageConflictPreferredPackages)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $(TargetFrameworkVersion.StartsWith('v1.'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $(TargetFrameworkVersion.StartsWith('v1.')) AND '$(DontTrimNETCoreAppRuntime)' != 'true'">
       <!-- on NetCoreApp 1.x PackageConflictPreferredPackages is not defined, but we want to trim the runtime packages -->
       <TrimmablePackages Include="%(FileDefinitions.PackageName)" Condition="'%(FileDefinitions.FileName)' ==  'System.Private.CoreLib.ni'" />
     </ItemGroup>

--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -24,6 +24,11 @@
       <!-- treat platform packages as trimmable -->
       <TrimmablePackages Include="$(PackageConflictPreferredPackages)" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $(TargetFrameworkVersion.StartsWith('v1.'))">
+      <!-- on NetCoreApp 1.x PackageConflictPreferredPackages is not defined, but we want to trim the runtime packages -->
+      <TrimmablePackages Include="%(FileDefinitions.PackageName)" Condition="'%(FileDefinitions.FileName)' ==  'System.Private.CoreLib.ni'" />
+    </ItemGroup>
   </Target>
 
   <Target Name="TrimFilesOnBuild"


### PR DESCRIPTION
NETCore.App 1.x didn't set the properties I use for identifying the runtime package for trimming.

To handle this I'll find the runtime package by file lookup for System.Private.CoreLib.ni.dll.  I've added an override to disable this as well.

Fixes #226 

/cc @terrajobst @weshaggard 