### PR TITLE
Remove RuntimeInformation and ValueTuple from the net461 shim set

### DIFF
--- a/netstandard/pkg/shims/netstandard/dir.props
+++ b/netstandard/pkg/shims/netstandard/dir.props
@@ -12,6 +12,8 @@
     <!-- Some assemblies that ship with implementatiosn in NetFx should not ship as a netfx shim -->
     <PackageForNetFx Condition="'$(MSBuildProjectName)' == 'System.IO.Compression'">false</PackageForNetFx>
     <PackageForNetFx Condition="'$(MSBuildProjectName)' == 'System.Net.Http'">false</PackageForNetFx>
+    <PackageForNetFx Condition="'$(MSBuildProjectName)' == 'System.ValueTuple'">false</PackageForNetFx>
+    <PackageForNetFx Condition="'$(MSBuildProjectName)' == 'System.Runtime.InteropServices.RuntimeInformation'">false</PackageForNetFx>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These shouldn't be shims for net461 as they are implementation libraries.

Fixes https://github.com/dotnet/standard/issues/291. 

PTAL @ericstj 