### PR TITLE
Reverting SelfContained param to unblock VS 2017 RTM

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
+++ b/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets
@@ -48,8 +48,7 @@
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)"
-                              IsSelfContained="$(SelfContained)">
+                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
 
       <Output TaskParameter="AssembliesToPublish" ItemName="_LockFileAssemblies" />
 


### PR DESCRIPTION
Revert https://github.com/dotnet/standard/pull/283/commits/0f48be1ecbdf1ec7ae655ae0f1b6a57722181671

This is a breaking change which makes the Packaging.Tools not be able to be used with the MSBuild Tasks that shipped with VS 2017 RTM.

This code is in the dotnet/sdk now, so this parameter isn't necessary.

/cc @davidfowl 