### PR TITLE
Allow override of SourceBranch from VSTS definition.

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -144,7 +144,8 @@
       "value": "real"
     },
     "SourceBranch": {
-      "value": "master"
+      "value": "master",
+      "allowOverride": true
     },
     "PB_GitHubAuthToken": {
       "value": null,

--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -4,6 +4,42 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git clone",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "clone $(PB_VsoCorefxGitUrl) standard",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "standard",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "task": {
@@ -30,49 +66,8 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "build.cmd",
+        "filename": "$(Build.SourcesDirectory)\\standard\\build.cmd",
         "arguments": "-OfficialBuildId=$(OfficialBuildId) -- /p:SignType=real /p:MicroBuild_SigningEnabled=true",
-        "modifyEnvironment": "false",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "NuGet Publisher ",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "333b11bd-d341-40d9-afcf-b32d5ce6f25b",
-        "versionSpec": "0.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "searchPattern": "bin/packages/**/*.nupkg;-:bin/packages/**/*.symbols.nupkg",
-        "nuGetFeedType": "external",
-        "connectedServiceName": "e3b269d4-5b99-4a32-a6ff-2c2feb920051",
-        "feedName": "",
-        "nuGetAdditionalArgs": "",
-        "verbosity": "Detailed",
-        "nuGetVersion": "3.5.0.1829",
-        "nuGetPath": ""
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Update dotnet/versions",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "build.cmd",
-        "arguments": "-- /v:diagnostic /t:UpdatePublishedVersions /p:GitHubUser=\"dotnet-build-bot\" /p:GitHubEmail=\"dotnet-build-bot@microsoft.com\"  /p:GitHubAuthToken=\"$(PB_GitHubAuthToken)\" /p:VersionsRepoOwner=\"$(VersionsRepoOwner)\" /p:VersionsRepo=\"versions\" /p:VersionsRepoPath=\"build-info/dotnet/$(PB_GitHubRepositoryName)/$(SourceBranch)\" /p:ShippedNuGetPackageGlobPath=\"bin/packages/Debug/*.nupkg\"",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -144,8 +139,7 @@
       "value": "real"
     },
     "SourceBranch": {
-      "value": "master",
-      "allowOverride": true
+      "value": "master"
     },
     "PB_GitHubAuthToken": {
       "value": null,


### PR DESCRIPTION
Allow VSTS definition to override the `SourceBranch `property, which is set to `master `as default.  This behavior makes it consistent with https://github.com/dotnet/corefx/blob/release/2.0.0/buildpipeline/DotNet-CoreFx-Trusted-Windows.json#L446

If this change is fine then we should make similar change in `master `so that the change is included in subsequent release forks.

@weshaggard @dagood PTAL.
