### PR TITLE
Fix incorrect forcedPackageRank comparison in ConflictResolver

### DIFF
--- a/Microsoft.Packaging.Tools/tasks/ConflictResolver.cs
+++ b/Microsoft.Packaging.Tools/tasks/ConflictResolver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 return item1;
             }
 
-            if (forcedPackageRank1 < forcedPackageRank2)
+            if (forcedPackageRank2 < forcedPackageRank1)
             {
                 log.LogMessage($"{conflictMessage}.  Choosing {item2.DisplayName} because package it comes from a package that is forced.");
                 return item2;


### PR DESCRIPTION
In checking forced package ranks, smaller ranked package should be winner.
