### PR TITLE
Increase publish timeout from 5 to 60 minutes

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -53,7 +53,7 @@
         "nuGetFeedType": "external",
         "connectedServiceName": "e3b269d4-5b99-4a32-a6ff-2c2feb920051",
         "feedName": "",
-        "nuGetAdditionalArgs": "",
+        "nuGetAdditionalArgs": "-Timeout 3600",
         "verbosity": "Detailed",
         "nuGetVersion": "3.5.0.1829",
         "nuGetPath": ""


### PR DESCRIPTION
This brings Standard's push in line with other repos and might let more builds pass.