### PR TITLE
Remove NuGet metadata

### DIFF
--- a/netstandard/pkg/targets/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/NETStandard.Library.targets
@@ -9,15 +9,11 @@
       <Private>false</Private>
       <NuGetPackageId>NETStandard.Library</NuGetPackageId>
       <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-      <NuGetSourceType>Package</NuGetSourceType>
     </Reference>
     <ReferenceCopyLocalPaths Condition="'$(_NetStandardLibraryLibPath)' != ''" Include="$(_NetStandardLibraryLibPath)*.dll">
       <Private>false</Private>
       <NuGetPackageId>NETStandard.Library</NuGetPackageId>
       <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-      <NuGetSourceType>Package</NuGetSourceType>
     </ReferenceCopyLocalPaths>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This metadata is read by SDK targets and can trip them up
since these packages don't appear in the deps file.

/cc @eerhardt @weshaggard 