### PR TITLE
Update shim versions to match the netfx

### DIFF
--- a/apicompat/netstandard1x/netstandard.builds
+++ b/apicompat/netstandard1x/netstandard.builds
@@ -26,6 +26,9 @@
     <Project Include="netstandard1x.depproj">
       <AdditionalProperties>%(AdditionalProperties);TargetFramework=netstandard1.6;NuGetTargetMoniker=.NETStandard,Version=v1.6</AdditionalProperties>
     </Project>
+    <Project Include="netstandard1x.depproj">
+      <AdditionalProperties>%(AdditionalProperties);TargetFramework=net47;NuGetTargetMoniker=.NETFramework,Version=v4.7</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/apicompat/netstandard1x/netstandard1x.depproj
+++ b/apicompat/netstandard1x/netstandard1x.depproj
@@ -15,7 +15,7 @@
       <Version>1.6.1</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'net47'">
     <PackageReference Include="Microsoft.Win32.Primitives">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/netstandard/pkg/shims/generateshims.ps1
+++ b/netstandard/pkg/shims/generateshims.ps1
@@ -49,7 +49,7 @@ foreach ($shim in $shimList)
     Write-Host "Generating forwards and project for $shimContract";
 
     $asmName = [System.Reflection.AssemblyName]::GetAssemblyName($shimContract);
-    $asmVersion = $asmName.Version.ToString();
+    $asmVersion = $asmName.Version;
 
     if ($refVersionPath -ne "" -and (Test-Path "$refVersionPath\$shim.dll"))
     {
@@ -57,10 +57,14 @@ foreach ($shim in $shimList)
 
         if ($asmRefVersion.Version -gt $asmName.Version)
         {
-            $asmVersion = $asmRefVersion.Version.ToString();
+            $asmVersion = $asmRefVersion.Version;
         }
     }
 
+    # Increment the patch version by 1 above the highest stable release to ensure we are higher then any servicing
+    $asmVersion = new-object System.Version($asmVersion.Major, $asmVersion.Minor, ($asmVersion.Build+1), 0)
+
+    $asmVersion = $asmVersion.ToString()
     $asmToken = $asmName.GetPublicKeyToken()[0].ToString("x2");
     if ($asmToken -eq "b0")
     {

--- a/netstandard/pkg/shims/netstandard/Microsoft.Win32.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/Microsoft.Win32.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/Microsoft.Win32.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/Microsoft.Win32.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.AppContext.csproj
+++ b/netstandard/pkg/shims/netstandard/System.AppContext.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.AppContext</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.AppContext.csproj
+++ b/netstandard/pkg/shims/netstandard/System.AppContext.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.AppContext</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.Concurrent.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.Concurrent.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.NonGeneric.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.NonGeneric.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.NonGeneric</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.NonGeneric.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.NonGeneric.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.NonGeneric</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.Specialized.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.Specialized.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.Specialized</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.Specialized.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.Specialized.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.Specialized</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Collections.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Collections.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.EventBasedAsync.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.EventBasedAsync.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel.EventBasedAsync</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel.Primitives</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel.Primitives</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.TypeConverter.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.TypeConverter.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel.TypeConverter</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.TypeConverter.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.TypeConverter.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel.TypeConverter</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ComponentModel.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ComponentModel.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ComponentModel</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Console.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Console.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Console</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Console.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Console.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Console</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Data.Common.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Data.Common.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Data.Common</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Data.Common.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Data.Common.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Data.Common</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Contracts.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Contracts.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Contracts</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Debug.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Debug.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Debug</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.FileVersionInfo.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.FileVersionInfo.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.FileVersionInfo</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.FileVersionInfo.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.FileVersionInfo.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.FileVersionInfo</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Process.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Process.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Process</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Process.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Process.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Process</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.StackTrace.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.StackTrace.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.StackTrace</AssemblyName>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.StackTrace.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.StackTrace.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.StackTrace</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.TextWriterTraceListener.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.TextWriterTraceListener</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.TextWriterTraceListener.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.TextWriterTraceListener</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Tools.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Tools.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Tools</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.TraceSource.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.TraceSource.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.TraceSource</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.TraceSource.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.TraceSource.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.TraceSource</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Tracing.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Tracing.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Diagnostics.Tracing.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Diagnostics.Tracing.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Drawing.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Drawing.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Drawing.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Drawing.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Drawing.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Drawing.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Dynamic.Runtime.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Dynamic.Runtime.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Dynamic.Runtime</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Globalization.Calendars.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Globalization.Calendars.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Globalization.Calendars.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Globalization.Calendars.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Globalization.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Globalization.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Globalization.Extensions</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Globalization.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Globalization.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Globalization.Extensions</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Globalization.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Globalization.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Globalization</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Compression.ZipFile.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Compression.ZipFile.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Compression.ZipFile.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Compression.ZipFile.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Compression.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Compression.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Compression</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Compression.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Compression.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Compression</AssemblyName>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.DriveInfo.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.DriveInfo.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.DriveInfo</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.DriveInfo.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.DriveInfo.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.DriveInfo</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Watcher.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Watcher.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.Watcher</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Watcher.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.Watcher.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem.Watcher</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.FileSystem.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.FileSystem.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.FileSystem</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.IsolatedStorage.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.IsolatedStorage.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.IsolatedStorage</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.MemoryMappedFiles.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.MemoryMappedFiles.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.MemoryMappedFiles</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.MemoryMappedFiles.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.MemoryMappedFiles.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.MemoryMappedFiles</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Pipes.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Pipes.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Pipes</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.Pipes.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.Pipes.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Pipes</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.UnmanagedMemoryStream.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.UnmanagedMemoryStream.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.UnmanagedMemoryStream</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.UnmanagedMemoryStream.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.UnmanagedMemoryStream.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.UnmanagedMemoryStream</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.IO.csproj
+++ b/netstandard/pkg/shims/netstandard/System.IO.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.Expressions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.Expressions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.Expressions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.Expressions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.Parallel.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.Parallel.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq.Parallel</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.Queryable.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.Queryable.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq.Queryable</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Linq.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Linq.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Http.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Http.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Http</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.NameResolution.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.NameResolution.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.NameResolution</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.NameResolution.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.NameResolution.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.NameResolution</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.NetworkInformation.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.NetworkInformation.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.NetworkInformation</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.NetworkInformation.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.NetworkInformation.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.NetworkInformation</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Ping.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Ping.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Ping</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Ping.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Ping.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Ping</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Requests.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Requests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Requests</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Security.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Security.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Security</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Security.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Security.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Security</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Sockets.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Sockets.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Sockets</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.Sockets.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.Sockets.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Sockets</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.WebHeaderCollection.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.WebHeaderCollection.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.WebHeaderCollection</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.WebSockets.Client.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.WebSockets.Client.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.WebSockets.Client</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.WebSockets.Client.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.WebSockets.Client.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.WebSockets.Client</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.WebSockets.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.WebSockets.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.WebSockets</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Net.WebSockets.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Net.WebSockets.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.WebSockets</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ObjectModel.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ObjectModel.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ObjectModel</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Reflection.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Reflection.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Reflection.Extensions</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Reflection.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Reflection.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Reflection.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Reflection.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Reflection.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Reflection</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Reflection.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Reflection.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Reflection</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Resources.Reader.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Resources.Reader.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Resources.Reader</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Resources.ResourceManager.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Resources.ResourceManager.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Resources.ResourceManager</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Resources.Writer.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Resources.Writer.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Resources.Writer</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.CompilerServices.VisualC.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.CompilerServices.VisualC.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.CompilerServices.VisualC</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.CompilerServices.VisualC.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.CompilerServices.VisualC.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.CompilerServices.VisualC</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Extensions</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Extensions</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Handles.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Handles.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Handles</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.InteropServices.RuntimeInformation</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.InteropServices</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.InteropServices.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.InteropServices</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Numerics.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Numerics.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Numerics</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Formatters.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Formatters.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Formatters</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Json.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Json.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Json</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Primitives</AssemblyName>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Primitives</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Xml.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Xml.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Xml.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.Serialization.Xml.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Runtime.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Runtime.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Claims.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Claims.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Claims</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Claims.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Claims.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Claims</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Algorithms.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Algorithms.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.2.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Algorithms.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Algorithms.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Csp.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Csp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Csp.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Csp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Encoding.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Encoding.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Encoding</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Encoding.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Encoding.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Encoding</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Primitives.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.X509Certificates.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.X509Certificates.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Cryptography.X509Certificates.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Cryptography.X509Certificates.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.Principal.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.Principal.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.Principal</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.SecureString.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.SecureString.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.SecureString</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Security.SecureString.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Security.SecureString.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Security.SecureString</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Text.Encoding.Extensions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Text.Encoding.Extensions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Text.Encoding.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Text.Encoding.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Text.Encoding</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Text.RegularExpressions.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Text.RegularExpressions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Overlapped.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Overlapped.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Overlapped</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Overlapped.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Overlapped.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Overlapped</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Tasks.Parallel.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Tasks.Parallel.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Tasks.Parallel</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Tasks.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Tasks.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Tasks</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Thread.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Thread.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Thread</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Thread.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Thread.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Thread</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.ThreadPool.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.ThreadPool.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.ThreadPool</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.ThreadPool.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.ThreadPool.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.ThreadPool</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.Timer.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.Timer.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading.Timer</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Threading.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Threading.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Threading</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.ValueTuple.csproj
+++ b/netstandard/pkg/shims/netstandard/System.ValueTuple.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ValueTuple</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.ReaderWriter.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.ReaderWriter.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XDocument.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XDocument</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XPath.XDocument.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XPath.XDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XPath.XDocument.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XPath.XDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XPath.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XPath.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XPath</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XPath.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XPath.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XPath</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XmlDocument.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XmlDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XmlDocument.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XmlDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>

--- a/netstandard/pkg/shims/netstandard/System.Xml.XmlSerializer.csproj
+++ b/netstandard/pkg/shims/netstandard/System.Xml.XmlSerializer.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
In order for the shims in this package and transitively the
NETStandard.Library.NETFramework package to have a higher assembly
version we need to update the versions to match the ones that we shipped
in the latest stable individual packages for netfx.

PTAL @ericstj @eerhardt @AlexGhiondea 