### PR TITLE
Update uap10.1 TFM to uap10.0.15138

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -157,4 +157,8 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
+  <!-- Target Framework Moniker values to be used in our projects -->
+  <PropertyGroup>
+    <UapRs3Tfm>uap10.0.15138</UapRs3Tfm>
+  </PropertyGroup>
 </Project>

--- a/netstandard/pkg/NETStandard.Library.dependencies.props
+++ b/netstandard/pkg/NETStandard.Library.dependencies.props
@@ -144,7 +144,7 @@
       <TargetFramework>netcoreapp2.0</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
-      <TargetFramework>uap10.1</TargetFramework>
+      <TargetFramework>uap10.0.15138</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
       <TargetFramework>net461</TargetFramework>

--- a/netstandard/pkg/NETStandard.Library.dependencies.props
+++ b/netstandard/pkg/NETStandard.Library.dependencies.props
@@ -144,7 +144,7 @@
       <TargetFramework>netcoreapp2.0</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
-      <TargetFramework>uap10.0.15138</TargetFramework>
+      <TargetFramework>$(UapRs3Tfm)</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
       <TargetFramework>net461</TargetFramework>


### PR DESCRIPTION
As we have worked out with VS ( @joshfree and @joperezr can report ), VS will use uap10.0.xxxxx for their restore TFM, and this particular TFM matches what the recently-modified UWP metapackage is using.