### PR TITLE
Add Xamarin.Mac to net-standard support table

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -18,6 +18,7 @@ most target .NET Standard 1.1.
 |.NET Framework             |   **4.5**|**4.5**|**4.5.1**| **4.6**|**4.6.1**|4.6.1 ~~4.6.2~~|4.6.1 ~~vNext~~|4.6.1|
 |Mono                       |   **4.6**|    4.6|      4.6|     4.6|   4.6|   4.6|   4.6| **vNext**|
 |Xamarin.iOS                |  **10.0**|   10.0|     10.0|    10.0|  10.0|  10.0|  10.0| **vNext**|
+|Xamarin.Mac                |   **3.0**|    3.0|      3.0|     3.0|   3.0|   3.0|   3.0| **vNext**|
 |Xamarin.Android            |   **7.0**|    7.0|      7.0|     7.0|   7.0|   7.0|   7.0| **vNext**|
 |Universal Windows Platform |  **10.0**|   10.0|     10.0|    10.0|  10.0| **vNext**| vNext| vNext|
 |Windows                    |   **8.0**|    8.0|  **8.1**|        |      |      |      |      |


### PR DESCRIPTION
- Fixes: https://github.com/dotnet/standard/issues/419
- Related PR: https://github.com/dotnet/docs/pull/2584