### PR TITLE
Stabilize NETStandard.Library 2.0 package version

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -157,4 +157,7 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
+  <!-- Use Roslyn Compilers to build -->
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
 </Project>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -318,7 +318,8 @@
     "NETStandard.Library": {
       "StableVersions": [
         "1.6.0",
-        "1.6.1"
+        "1.6.1",
+        "2.0.0"
       ],
       "BaselineVersion": "2.0.0",
       "InboxOn": {}


### PR DESCRIPTION
Also includes a fix to enable building this repo from a VS2017 cmd prompt. 