### PR TITLE
Disable continueOnError for dotnet/versions update

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -61,7 +61,7 @@
     },
     {
       "enabled": true,
-      "continueOnError": true,
+      "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Update dotnet/versions",
       "timeoutInMinutes": 0,


### PR DESCRIPTION
This step is responsible for flowing new package versions to other repos. When it stops working, we should know about it. Failure won't block NuGet package publish--it's before dotnet/versions update.

https://github.com/dotnet/core-eng/issues/1258

/cc @jcagme