### PR TITLE
Handle file duplicates in trimming

### DIFF
--- a/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
@@ -307,14 +307,16 @@ namespace Microsoft.DotNet.Build.Tasks
             foreach(var runtimeItem in runtimeItems)
             {
                 var fileNode = new FileNode(runtimeItem, packages);
-                files.Add(fileNode.Name, fileNode);
+
+                // last in wins
+                files[fileNode.Name] = fileNode;
             }
 
             // root files are likely not in the RuntimeItems
             foreach (var rootFile in RootFiles)
             {
                 var fileNode = new FileNode(rootFile, packages);
-                if (!files.ContainsKey(fileNode.Name)  && File.Exists(fileNode.SourceFile))
+                if (!files.ContainsKey(fileNode.Name) && File.Exists(fileNode.SourceFile))
                 {
                     files.Add(fileNode.Name, fileNode);
                 }


### PR DESCRIPTION
Use last-in-wins (similar to what will happen with overwrite during
copy to output) when building the file graph.

We could instead merge the dependencies of the additional file but
that's not necessarily correct.

Fixes #378 

/cc @weshaggard 