### PR TITLE
Workaround xbuild

### DIFF
--- a/netstandard/pkg/targets/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/NETStandard.Library.targets
@@ -3,8 +3,8 @@
     <NETStandardLibraryPackageVersion>#VERSION#</NETStandardLibraryPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Condition="'$(_NetStandardLibraryRefPath)' != ''" Include="$(_NetStandardLibraryRefPath)*.dll">
+  <ItemGroup Condition="'$(_NetStandardLibraryRefPath)' != ''">
+    <Reference Include="$(_NetStandardLibraryRefPath)*.dll">
       <!-- Private = false to make these reference only -->
       <Private>false</Private>
       <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->

--- a/netstandard/pkg/targets/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/NETStandard.Library.targets
@@ -13,11 +13,5 @@
       <NuGetPackageId>NETStandard.Library</NuGetPackageId>
       <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
     </Reference>
-    <ReferenceCopyLocalPaths Condition="'$(_NetStandardLibraryLibPath)' != ''" Include="$(_NetStandardLibraryLibPath)*.dll">
-      <Private>false</Private>
-      <Facade Condition="'%(FileName)' != 'netstandard'">true</Facade>
-      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
-      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-    </ReferenceCopyLocalPaths>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
/cc @weshaggard 

XBuild was throwing NRE when loading these targets in a non-netstandard2.0 project.  The issue was related to evaluating item metadata despite the condition being false.  I found I could workaround it by moving the condition to the itemgroup.  

I also noticed we still had ReferenceCopyLocalPaths despite never shipping any implementation assemblies in this package, so I've removed it.

Fixes #862