### PR TITLE
Trimming packages config

### DIFF
--- a/Microsoft.Packaging.Tools.Trimming/tasks/FileNode.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/FileNode.cs
@@ -58,6 +58,11 @@ namespace Microsoft.DotNet.Build.Tasks
         public NuGetPackageNode Package { get; }
         public IEnumerable<FileNode> Dependencies { get { return dependencies; } }
 
+        public override string ToString()
+        {
+            return Name;
+        }
+
         public void PopulateDependencies(IDictionary<string, FileNode> allFiles, bool preferNativeImage, ILog log)
         {
             if (dependencies == null)
@@ -73,15 +78,17 @@ namespace Microsoft.DotNet.Build.Tasks
                 stack = new Stack<FileNode>();
             }
 
-            stack.Push(this);
+            if (stack.Contains(this))
+            {
+                log.LogMessage($"Cycle detected: {String.Join(" -> ", stack)} -> {this}");
+            }
 
             if (dependencies != null)
             {
-                // re-entrant call indicates a cycle, bail
-                log.LogMessage($"Cycle detected: {String.Join(" -> ", stack)}");
-                stack.Pop();
                 return;
             }
+
+            stack.Push(this);
 
             dependencies = new HashSet<FileNode>();
 

--- a/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
@@ -50,7 +50,6 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <summary>
         /// Target framework to use when determining package dependencies.  Should be long form, IE: .NETCoreApp,Version=v1.0
         /// </summary>
-        [Required]
         public string TargetFramework { get; set; }
 
         /// <summary>
@@ -250,6 +249,12 @@ namespace Microsoft.DotNet.Build.Tasks
         internal IDictionary<string, NuGetPackageNode> GetPackagesFromPackageDependencies()
         {
             Dictionary<string, NuGetPackageNode> packages = new Dictionary<string, NuGetPackageNode>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrEmpty(TargetFramework) && PackageDependencies?.Length > 0)
+            {
+                Log.LogError($"{nameof(TargetFramework)} was not specified and is required when {nameof(PackageDependencies)} are present.");
+                return packages;
+            }
 
             var target = TargetFramework;
 


### PR DESCRIPTION
A couple minor fixes to trimming that reduce some noisy messages and make it work with old packages.config CSProjs that have no nuget targets.

Fixes #377 

/cc @Petermarcu @weshaggard 