### PR TITLE
[release/2.0.0] Move condition to itemgroup to workaround XBuild bug

### DIFF
--- a/netstandard/pkg/targets/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/NETStandard.Library.targets
@@ -3,8 +3,8 @@
     <NETStandardLibraryPackageVersion>#VERSION#</NETStandardLibraryPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Condition="'$(_NetStandardLibraryRefPath)' != ''" Include="$(_NetStandardLibraryRefPath)*.dll">
+  <ItemGroup Condition="'$(_NetStandardLibraryRefPath)' != ''">
+    <Reference Include="$(_NetStandardLibraryRefPath)*.dll">
       <!-- Private = false to make these reference only -->
       <Private>false</Private>
       <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->


### PR DESCRIPTION
See https://github.com/dotnet/core/issues/862

XBuild will null-ref when it tries to evaluate metadata on this Reference item,
even when the condition on the item is false.  Avoid this by moving
the condition to the ItemGroup.

Port of 969ce9a97076c0a052e1f0fa6108bae0cc2d840e