### PR TITLE
Update uap10.1 TFM to uap10.0.15138 and rev up Netstandard package version

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -160,4 +160,9 @@
   <!-- Use Roslyn Compilers to build -->
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
+  
+  <!-- Target Framework Moniker values to be used in our projects -->
+  <PropertyGroup>
+    <UapRs3Tfm>uap10.0.15138</UapRs3Tfm>
+  </PropertyGroup>
 </Project>

--- a/netstandard/pkg/NETStandard.Library.dependencies.props
+++ b/netstandard/pkg/NETStandard.Library.dependencies.props
@@ -144,7 +144,7 @@
       <TargetFramework>netcoreapp2.0</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
-      <TargetFramework>uap10.1</TargetFramework>
+      <TargetFramework>$(UapRs3Tfm)</TargetFramework>
     </_dependency>
     <_dependency Include="$(PlatformPackageId)">
       <TargetFramework>net461</TargetFramework>

--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <OmitDependencies>true</OmitDependencies>


### PR DESCRIPTION
cc: @weshaggard @Petermarcu @ericstj @joshfree 

Fixing Netstandard.Library package and reving up the package version to 2.0.1