### PR TITLE
[dev/release/2.0.0] Move web sources before potentially local sources

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -30,9 +30,9 @@
   <!-- list of nuget package sources passed to dotnet -->
   <PropertyGroup>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      $(RestoreSources);
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://api.nuget.org/v3/index.json
+      https://api.nuget.org/v3/index.json;
+      $(RestoreSources)
     </RestoreSources>
   </PropertyGroup>
 


### PR DESCRIPTION
Followup to https://github.com/dotnet/standard/pull/523 (initial API implementation). Adds a workaround to a `--source` bug that I added to the CoreFX repo API PR discussed at https://github.com/dotnet/corefx/pull/24378#discussion_r142285244.