### PR TITLE
Change feed source

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -30,7 +30,7 @@
   <!-- list of nuget package sources passed to dotnet -->
   <PropertyGroup>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
       $(RestoreSources)


### PR DESCRIPTION
package feed version change for this branch was auto-updated via maestro (and I just merged the change).  This change is updating the default TF restore url.  I've already updated the Pipebuild definition in VSTS.