### PR TITLE
Remove obsolete attribute from XslTransform

### DIFF
--- a/netstandard/ref/System.Xml.cs
+++ b/netstandard/ref/System.Xml.cs
@@ -3411,7 +3411,6 @@ namespace System.Xml.Xsl
         public abstract string Message { get; }
     }
     public delegate void XsltMessageEncounteredEventHandler(object sender, System.Xml.Xsl.XsltMessageEncounteredEventArgs e);
-    [System.ObsoleteAttribute("This class has been deprecated. Please use System.Xml.Xsl.XslCompiledTransform instead. http://go.microsoft.com/fwlink/?linkid=14202")]
     public sealed partial class XslTransform
     {
         public XslTransform() { }


### PR DESCRIPTION
This is part of https://github.com/dotnet/corefx/issues/25874. 

After the updated standard reaches CoreFX we can remove the attribute there too.

The same attribute is present in various platforms, should I remove it there too?
```
platforms\net461\System.Xml.cs
platforms\xamarin.android\System.Xml.cs
platforms\xamarin.ios\System.Xml.cs
platforms\xamarin.mac\System.Xml.cs
platforms\xamarin.tvos\System.Xml.cs
platforms\xamarin.watchos\System.Xml.cs
```