### PR TITLE
Don't fail trimming on missing files

### DIFF
--- a/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/TrimFiles.cs
@@ -149,6 +149,11 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     var fileNode = fileRoots.Dequeue();
 
+                    if (fileNode.IsMissing)
+                    {
+                        Log.LogWarning($"File {fileNode.SourceFile} was included through references or roots but the file was missing.  It's dependencies will also be missing from the trimmed output.");
+                    }
+
                     foreach(var file in fileNode.Dependencies.Where(f => !trimmable.IsFileTrimmable(f.Name)))
                     {
                         IncludeNode(fileRoots, file);

--- a/Microsoft.Packaging.Tools.Trimming/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/targets/Microsoft.Packaging.Tools.Trimming.targets
@@ -56,12 +56,13 @@
     </ItemGroup>
   </Target>
   
-  <PropertyGroup Condition="'$(TrimUnusedDependencies)' == 'true'">
+  <PropertyGroup Condition="'$(TrimUnusedDependencies)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
     <TrimFilesOnBuildAfter>CoreCompile</TrimFilesOnBuildAfter>
     <TrimFilesOnPublishBefore>ComputeFilesToPublish</TrimFilesOnPublishBefore>
   </PropertyGroup>
 
   <Target Name="TrimFilesOnBuild"
+          Condition="'$(BuildingProject)' == 'true'"
           DependsOnTargets="_determineTrimPackageInputs"
           AfterTargets="$(TrimFilesOnBuildAfter)">
     <ItemGroup>
@@ -95,6 +96,7 @@
   </Target>
 
   <Target Name="TrimFilesOnPublish"
+          Condition="'$(BuildingProject)' == 'true'"
           DependsOnTargets="_determineTrimPackageInputs"
           BeforeTargets="$(TrimFilesOnPublishBefore)">
 


### PR DESCRIPTION
Instead, warn if that file happens to be included in the closure.

Fixes #697

It's still not clear to me this is required, but we can add it.  It may even be more appropriate to error.