### PR TITLE
[release/2.0.0] Fix old project system warnings

### DIFF
--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <OmitDependencies>true</OmitDependencies>

--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -36,7 +36,7 @@
 
   <Target Name="StampTargets" BeforeTargets="GenerateNuSpec">
     <PropertyGroup>
-      <_FacadeFiles Condition="'%(File.Facade)' == 'true' AND '%(File.Extension)' == '.dll'" >@(File->'%24(MSBuildThisFileDirectory)\ref\%(FileName)%(Extension)')</_FacadeFiles>
+      <_FacadeFiles Condition="'%(File.Facade)' == 'true' AND '%(File.Extension)' == '.dll'" >@(File->'%24(MSBuildThisFileDirectory)ref\%(FileName)%(Extension)')</_FacadeFiles>
     </PropertyGroup>
     <Error Condition="'$(_FacadeFiles)' == ''" Text="Could not determine facade file names to write to targets" />
 

--- a/netstandard/pkg/targets/netstandard/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/netstandard/NETStandard.Library.targets
@@ -6,24 +6,30 @@
   <!-- Only add references if we're actually targeting .NETStandard.
        If the project is targeting some other TFM that is compatible with NETStandard we expect
        that framework to provide all references for NETStandard, mscorlib, System.* in their own
-       targeting pack / SDK. -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <Reference Include="$(MSBuildThisFileDirectory)\ref\netstandard.dll">
-      <!-- Private = false to make these reference only -->
-      <Private>false</Private>
-      <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->
-      <Visible>false</Visible>
-      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
-      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>    
-    </Reference>
-    <Reference Include="#NETSTANDARDFACADES#">
-      <Facade>true</Facade>
-      <!-- Private = false to make these reference only -->
-      <Private>false</Private>
-      <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->
-      <Visible>false</Visible>
-      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
-      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-    </Reference>
-  </ItemGroup>
+       targeting pack / SDK.
+       Choose/When is required to avoid an issue where the old desktop project system in VS 
+       will evaluate this item ignoring the condition in order to populate the references. -->
+  <Choose>
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+      <ItemGroup>
+        <Reference Include="$(MSBuildThisFileDirectory)\ref\netstandard.dll">
+          <!-- Private = false to make these reference only -->
+          <Private>false</Private>
+          <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->
+          <Visible>false</Visible>
+          <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+          <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>    
+        </Reference>
+        <Reference Include="#NETSTANDARDFACADES#">
+          <Facade>true</Facade>
+          <!-- Private = false to make these reference only -->
+          <Private>false</Private>
+          <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->
+          <Visible>false</Visible>
+          <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+          <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/netstandard/pkg/targets/netstandard/NETStandard.Library.targets
+++ b/netstandard/pkg/targets/netstandard/NETStandard.Library.targets
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
       <ItemGroup>
-        <Reference Include="$(MSBuildThisFileDirectory)\ref\netstandard.dll">
+        <Reference Include="$(MSBuildThisFileDirectory)ref\netstandard.dll">
           <!-- Private = false to make these reference only -->
           <Private>false</Private>
           <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->


### PR DESCRIPTION
When NETStandard.Library was referenced in a .NETFramework project using the old project system,
it would evaluate the project ignoring conditions on ItemGroups. Apparently this is done to
display the superset of project configurations (eg both debug and release) in the solution heirarchy.
The warnings were a result of the items never being resolved after design time build finished
resolving references (because of course the items were conditioned out for the target framework).

We can workaround this using choose/when. Apparently the evaluation of the project is bold
enough to ignore the conditions on an itemgroup, but not bold enough to choose one of many
when (or all) clauses. :)

Fixes #708

Release version of https://github.com/dotnet/standard/pull/710