### PR TITLE
Fix LockFileCache when SDK and trimming task are using different NuGet dlls

### DIFF
--- a/Microsoft.Packaging.Tools.Trimming/tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
@@ -12,7 +12,8 @@ namespace Microsoft.NET.Build.Tasks
     internal class LockFileCache
     {
         private IBuildEngine4 _buildEngine;
-        
+        private static string taskObjectPrefix = null;
+
         public LockFileCache(IBuildEngine4 buildEngine)
         {
             _buildEngine = buildEngine;
@@ -45,7 +46,12 @@ namespace Microsoft.NET.Build.Tasks
 
         private static string GetTaskObjectKey(string lockFilePath)
         {
-            return $"{nameof(LockFileCache)}:{lockFilePath}";
+            if (taskObjectPrefix == null)
+            {
+                taskObjectPrefix = typeof(LockFile).AssemblyQualifiedName;
+            }
+
+            return $"{taskObjectPrefix}:{lockFilePath}";
         }
 
         private LockFile LoadLockFile(string path)


### PR DESCRIPTION
Previously I copied the SDK caching code for caching the loaded lock file across task boundaries.

This became a problem when the SDK updated their NuGet version.

We didn't agree on the type that belonged in the cache.

Avoid this by using a versioned prefix for the cache key.  Of course we will no longer share the read if we happen to be on the same version, but this is safer.

/cc @nguerrera @dsplaisted 