### PR TITLE
Use msbuild.cmd instead of invoking directly in 2.0.0

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -52,7 +52,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "msbuild",
+        "filename": "Tools/msbuild.cmd",
         "arguments": "publish.msbuild /t:SignPackages /p:SignType=$(SignType)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"


### PR DESCRIPTION
This is needed to build publish.msbuild in the pipebuild

CC @weshaggard 