### PR TITLE
Run msbuild.cmd from Tools dir relative to repo path in 2.0.0

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -52,7 +52,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "Tools/msbuild.cmd",
+        "filename": "$(Build.SourcesDirectory)/Tools/msbuild.cmd",
         "arguments": "publish.msbuild /t:SignPackages /p:SignType=$(SignType)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"


### PR DESCRIPTION
See https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?buildId=1689917&_a=summary. It appears I have to make the path to the Tools directory relative to the repo root.

CC @weshaggard @MattGal