### PR TITLE
Fix syntax for SignPackages in config.json master

### DIFF
--- a/config.json
+++ b/config.json
@@ -138,9 +138,7 @@
           "description": "Signs the NuGet packages.",
           "settings": {
             "Project": "packages.builds",
-            "settings":{
-              "SignPackages": "default"
-            },
+            "SignPackages": "default",
             "MsBuildLogging":"/flp:v=normal;LogFile=sign-packages.log"
           }
         },


### PR DESCRIPTION
For https://github.com/dotnet/standard/issues/737