### PR TITLE
Remove workingFolder from build.cmd invocation in signing packages in master

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -55,7 +55,7 @@
         "filename": "build.cmd",
         "arguments": "-signpackages -OfficialBuildId=$(OfficialBuildId) -- /p:SignType=$(SignType)",
         "modifyEnvironment": "false",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },


### PR DESCRIPTION
For https://github.com/dotnet/standard/issues/737