### PR TITLE
 Rename config.json task to avoid confusing run.cmd

### DIFF
--- a/buildpipeline/dotnet-standard-win.json
+++ b/buildpipeline/dotnet-standard-win.json
@@ -53,7 +53,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-signpackages -OfficialBuildId=$(OfficialBuildId) -- /p:SignType=$(SignType)",
+        "arguments": "-signpkgs -OfficialBuildId=$(OfficialBuildId) -- /p:SignType=$(SignType)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"

--- a/config.json
+++ b/config.json
@@ -134,10 +134,10 @@
             "MsBuildLogging":"/flp:v=normal;LogFile=build-packages.log"
           }
         },
-        "signpackages": {
+        "signpkgs": {
           "description": "Signs the NuGet packages.",
           "settings": {
-            "Project": "packages.builds",
+            "Project": "publish.msbuild",
             "SignPackages": "default",
             "MsBuildLogging":"/flp:v=normal;LogFile=sign-packages.log"
           }


### PR DESCRIPTION
For https://github.com/dotnet/standard/issues/737