### PR TITLE
Get access to build.common.targets in publish.msbuild in master

### DIFF
--- a/publish.msbuild
+++ b/publish.msbuild
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.targets" />
   <Import Project="$(PackagesDir)/$(FeedTasksPackage)/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
   <PropertyGroup>
      <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>


### PR DESCRIPTION
Without this, builds fail in signing because they don't have access to the `SignFiles` target. Importing dir.targets gets us build.common.targets from buildtools, which we need to run the Signing targets. Pattern here matches what is already in the other repos.