### PR TITLE
Add diagnostic logging to trimming

### DIFF
--- a/Microsoft.Packaging.Tools.Trimming/tasks/FileNode.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/FileNode.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Build.Tasks
         public string PackageId { get; }
         public string SourceFile { get; }
         public NuGetPackageNode Package { get; }
-        public IEnumerable<FileNode> Dependencies { get { return dependencies; } }
+        public IEnumerable<FileNode> Dependencies { get { return dependencies ?? Enumerable.Empty<FileNode>(); } }
         public IEnumerable<FileNode> RelatedFiles { get { return relatedFiles; } }
 
         public override string ToString()

--- a/Microsoft.Packaging.Tools.Trimming/tasks/NuGetPackageNode.cs
+++ b/Microsoft.Packaging.Tools.Trimming/tasks/NuGetPackageNode.cs
@@ -47,5 +47,10 @@ namespace Microsoft.DotNet.Build.Tasks
                 dependencyNode._dependencies.Add(this);
             }
         }
+
+        public override string ToString()
+        {
+            return Id;
+        }
     }
 }


### PR DESCRIPTION
Enable diagnostic logging to help understand the state of the task if a failure occurs.

Also guard against unpopulated dependencies.