### PR TITLE
Enable latest C# features

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -44,6 +44,7 @@
     <RunApiCompat>true</RunApiCompat>
     <AssemblyKey>Open</AssemblyKey>
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
In order to use `readonly struct`, `in` and by-ref structs we need at least C# 7.2. This will just follow CoreFx and default to latest language version.