### PR TITLE
Add DbProviderFactories

### DIFF
--- a/netstandard/ref/System.Data.Common.cs
+++ b/netstandard/ref/System.Data.Common.cs
@@ -724,6 +724,19 @@ namespace System.Data.Common
         protected abstract void SetParameter(int index, System.Data.Common.DbParameter value);
         protected abstract void SetParameter(string parameterName, System.Data.Common.DbParameter value);
     }
+    public static partial class DbProviderFactories
+    {
+        public static System.Data.Common.DbProviderFactory GetFactory(System.Data.Common.DbConnection connection) { throw null; }
+        public static System.Data.Common.DbProviderFactory GetFactory(System.Data.DataRow providerRow) { throw null; }
+        public static System.Data.Common.DbProviderFactory GetFactory(string providerInvariantName) { throw null; }
+        public static System.Data.DataTable GetFactoryClasses() { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> GetProviderInvariantNames() { throw null; }
+        public static void RegisterFactory(string providerInvariantName, System.Data.Common.DbProviderFactory factory) { }
+        public static void RegisterFactory(string providerInvariantName, string factoryTypeAssemblyQualifiedName) { }
+        public static void RegisterFactory(string providerInvariantName, System.Type providerFactoryClass) { }
+        public static bool TryGetFactory(string providerInvariantName, out System.Data.Common.DbProviderFactory factory) { factory = default(System.Data.Common.DbProviderFactory); throw null; }
+        public static bool UnregisterFactory(string providerInvariantName) { throw null; }
+    }
     public abstract partial class DbProviderFactory
     {
         protected DbProviderFactory() { }

--- a/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/netstandard/src/ApiCompatBaseline.net461.txt
@@ -21,6 +21,12 @@ CannotRemoveBaseTypeOrInterface : Type 'System.ValueTuple<T1, T2, T3, T4, T5, T6
 CannotRemoveBaseTypeOrInterface : Type 'System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' does not implement interface 'System.Runtime.CompilerServices.ITuple' in the implementation but it does in the contract.
 TypesMustExist : Type 'System.Data.Common.DbColumn' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Data.Common.DbDataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.GetProviderInvariantNames()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.RegisterFactory(System.String, System.Data.Common.DbProviderFactory)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.RegisterFactory(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.RegisterFactory(System.String, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.TryGetFactory(System.String, System.Data.Common.DbProviderFactory)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Data.Common.DbProviderFactories.UnregisterFactory(System.String)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Data.Common.IDbColumnSchemaGenerator' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Diagnostics.StackFrameExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Diagnostics.Tracing.EventCounter' does not exist in the implementation but it does exist in the contract.
@@ -69,4 +75,4 @@ MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.set(System.
 TypesMustExist : Type 'System.Threading.PreAllocatedOverlapped' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Threading.ThreadPoolBoundHandle' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Xml.XPath.XDocumentExtensions' does not exist in the implementation but it does exist in the contract.
-Total Issues: 70
+Total Issues: 76

--- a/netstandard/src/ApiCompatBaseline.xamarin.android.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.android.txt
@@ -1,1 +1,3 @@
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Data.Common.DbProviderFactories' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
@@ -1,1 +1,3 @@
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Data.Common.DbProviderFactories' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
@@ -1,1 +1,3 @@
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Data.Common.DbProviderFactories' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
@@ -1,1 +1,3 @@
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Data.Common.DbProviderFactories' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
+++ b/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
@@ -1,1 +1,3 @@
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Data.Common.DbProviderFactories' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/netstandard/src/GenApi.exclude.xamarin.android.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.android.txt
@@ -1,0 +1,1 @@
+T:System.Data.Common.DbProviderFactories

--- a/netstandard/src/GenApi.exclude.xamarin.ios.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.ios.txt
@@ -1,0 +1,1 @@
+T:System.Data.Common.DbProviderFactories

--- a/netstandard/src/GenApi.exclude.xamarin.mac.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.mac.txt
@@ -1,0 +1,1 @@
+T:System.Data.Common.DbProviderFactories

--- a/netstandard/src/GenApi.exclude.xamarin.tvos.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.tvos.txt
@@ -1,0 +1,1 @@
+T:System.Data.Common.DbProviderFactories

--- a/netstandard/src/GenApi.exclude.xamarin.watchos.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.watchos.txt
@@ -1,0 +1,1 @@
+T:System.Data.Common.DbProviderFactories


### PR DESCRIPTION
This fixes #707 and fixes #356.

This adds the `DbProviderFactories` that allows creating factorings for DB access.

@dotnet/nsboard 