### PR TITLE
Add RuntimeFeature

### DIFF
--- a/netstandard/ref/System.Runtime.CompilerServices.cs
+++ b/netstandard/ref/System.Runtime.CompilerServices.cs
@@ -437,6 +437,10 @@ namespace System.Runtime.CompilerServices
         public RuntimeCompatibilityAttribute() { }
         public bool WrapNonExceptionThrows { get { throw null; } set { } }
     }
+    public static partial class RuntimeFeature
+    {
+        public static bool IsSupported(string feature) { throw null; }
+    }
     public static partial class RuntimeHelpers
     {
         public static int OffsetToStringData { get { throw null; } }

--- a/netstandard/ref/System.Runtime.CompilerServices.cs
+++ b/netstandard/ref/System.Runtime.CompilerServices.cs
@@ -439,6 +439,7 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeFeature
     {
+        public const string PortablePdb = "PortablePdb";
         public static bool IsSupported(string feature) { throw null; }
     }
     public static partial class RuntimeHelpers

--- a/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/netstandard/src/ApiCompatBaseline.net461.txt
@@ -125,6 +125,7 @@ CannotMakeMemberNonVirtual : Member 'System.Reflection.TypeInfo.GetDeclaredPrope
 CannotMakeMemberNonVirtual : Member 'System.Reflection.TypeInfo.ImplementedInterfaces.get()' is non-virtual in the implementation but is virtual in the contract.
 CannotMakeMemberNonVirtual : Member 'System.Reflection.TypeInfo.IsAssignableFrom(System.Reflection.TypeInfo)' is non-virtual in the implementation but is virtual in the contract.
 TypesMustExist : Type 'System.Runtime.CompilerServices.ITuple' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeFeature' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.DataContractSerializerExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.ISerializationSurrogateProvider' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.SecureStringMarshal' does not exist in the implementation but it does exist in the contract.
@@ -169,4 +170,4 @@ TypesMustExist : Type 'System.Threading.ThreadPoolBoundHandle' does not exist in
 MembersMustExist : Member 'System.Threading.Tasks.Task.IsCompletedSuccessfully.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Threading.Tasks.TaskCanceledException..ctor(System.String, System.Exception, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Xml.XPath.XDocumentExtensions' does not exist in the implementation but it does exist in the contract.
-Total Issues: 170
+Total Issues: 171

--- a/netstandard/src/GenApi.exclude.net461.txt
+++ b/netstandard/src/GenApi.exclude.net461.txt
@@ -25,3 +25,4 @@ T:System.Xml.XPath.XDocumentExtensions
 T:System.Runtime.CompilerServices.ITuple
 T:System.Collections.Generic.CollectionExtensions
 T:System.Collections.Generic.KeyValuePair
+T:System.Runtime.CompilerServices.RuntimeFeature


### PR DESCRIPTION
This adds the `RuntimeFeature` class which enables compilers to statically discover which features the runtime is guaranteed to support. The compiler checks for individual features by looking for the presence of a static field by a well-known name. By convention, these fields are of type string.

Please note that for .NET Standard this means that adding a field to this type requires all implementers to provide this feature in their runtimes. The only feature we currently have is portable PDBs, which (AFAIK) all runtimes already support.

@dotnet/nsboard 