### PR TITLE
Add runtime API to get ECMA335 metadata

### DIFF
--- a/netstandard/ref/System.Reflection.Metadata.cs
+++ b/netstandard/ref/System.Reflection.Metadata.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Metadata
+{
+    public static partial class AssemblyExtensions
+    {
+        [System.CLSCompliantAttribute(false)]
+        public unsafe static bool TryGetRawMetadata(this System.Reflection.Assembly assembly, out byte* blob, out int length) { blob = default(byte*); length = default(int); throw null; }
+    }
+}

--- a/netstandard/ref/netstandard.csproj
+++ b/netstandard/ref/netstandard.csproj
@@ -66,6 +66,7 @@
     <Compile Include="System.Numerics.cs" />
     <Compile Include="System.Reflection.cs" />
     <Compile Include="System.Reflection.Emit.cs" />
+    <Compile Include="System.Reflection.Metadata.cs" />
     <Compile Include="System.Resources.cs" />
     <Compile Include="System.Runtime.CompilerServices.cs" />
     <Compile Include="System.Runtime.ConstrainedExecution.cs" />

--- a/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/netstandard/src/ApiCompatBaseline.net461.txt
@@ -31,6 +31,7 @@ MembersMustExist : Member 'System.Net.Http.HttpClientHandler.SslProtocols.set(Sy
 TypesMustExist : Type 'System.Net.Sockets.SocketReceiveFromResult' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Net.Sockets.SocketReceiveMessageFromResult' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Net.Sockets.SocketTaskExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Metadata.AssemblyExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.DataContractSerializerExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.ISerializationSurrogateProvider' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.SecureStringMarshal' does not exist in the implementation but it does exist in the contract.
@@ -51,4 +52,4 @@ MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.set(System.
 TypesMustExist : Type 'System.Threading.PreAllocatedOverlapped' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Threading.ThreadPoolBoundHandle' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Xml.XPath.XDocumentExtensions' does not exist in the implementation but it does exist in the contract.
-Total Issues: 52
+Total Issues: 53

--- a/netstandard/src/GenApi.exclude.net461.txt
+++ b/netstandard/src/GenApi.exclude.net461.txt
@@ -22,3 +22,4 @@ T:System.Security.Cryptography.TripleDESCng
 T:System.Threading.PreAllocatedOverlapped
 T:System.Threading.ThreadPoolBoundHandle
 T:System.Xml.XPath.XDocumentExtensions
+T:System.Reflection.Metadata.AssemblyExtensions


### PR DESCRIPTION
This adds an API that the runtime needs to implement to allow metadata readers to read the ECMA335 metadata without having to load the assembly again into memory. However, a valid implementation is `return false;` as it's primarily a perf optimization.

@dotnet/nsboard 