### PR TITLE
Add ReadOnlySequence<T> and friends

### DIFF
--- a/netstandard/ref/System.Buffers.cs
+++ b/netstandard/ref/System.Buffers.cs
@@ -15,6 +15,9 @@ namespace System.Buffers
     }
     public static partial class BuffersExtensions
     {
+        public static void CopyTo<T>(this in System.Buffers.ReadOnlySequence<T> source, System.Span<T> destination) { }
+        public static System.Nullable<System.SequencePosition> PositionOf<T>(this in System.Buffers.ReadOnlySequence<T> source, T value) where T : System.IEquatable<T> { throw null; }
+        public static T[] ToArray<T>(this in System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
         public static void Write<T>(this System.Buffers.IBufferWriter<T> writer, System.ReadOnlySpan<T> value) { }
     }
     public partial interface IBufferWriter<T>
@@ -68,6 +71,47 @@ namespace System.Buffers
         Done = 0,
         InvalidData = 3,
         NeedMoreData = 2,
+    }
+    public readonly partial struct ReadOnlySequence<T>
+    {
+        public static readonly System.Buffers.ReadOnlySequence<T> Empty;
+        public ReadOnlySequence(System.Buffers.ReadOnlySequenceSegment<T> startSegment, int startIndex, System.Buffers.ReadOnlySequenceSegment<T> endSegment, int endIndex) { throw null; }
+        public ReadOnlySequence(System.ReadOnlyMemory<T> memory) { throw null; }
+        public ReadOnlySequence(T[] array) { throw null; }
+        public ReadOnlySequence(T[] array, int start, int length) { throw null; }
+        public System.SequencePosition End { get { throw null; } }
+        public System.ReadOnlyMemory<T> First { get { throw null; } }
+        public bool IsEmpty { get { throw null; } }
+        public bool IsSingleSegment { get { throw null; } }
+        public long Length { get { throw null; } }
+        public System.SequencePosition Start { get { throw null; } }
+        public System.Buffers.ReadOnlySequence<T>.Enumerator GetEnumerator() { throw null; }
+        public System.SequencePosition GetPosition(long offset) { throw null; }
+        public System.SequencePosition GetPosition(long offset, System.SequencePosition origin) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(int start, int length) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(int start, System.SequencePosition end) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(long start) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(long start, long length) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(long start, System.SequencePosition end) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(System.SequencePosition start) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(System.SequencePosition start, int length) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(System.SequencePosition start, long length) { throw null; }
+        public System.Buffers.ReadOnlySequence<T> Slice(System.SequencePosition start, System.SequencePosition end) { throw null; }
+        public override string ToString() { throw null; }
+        public bool TryGet(ref System.SequencePosition position, out System.ReadOnlyMemory<T> memory, bool advance = true) { memory = default(System.ReadOnlyMemory<T>); throw null; }
+        public partial struct Enumerator
+        {
+            public Enumerator(in System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
+            public System.ReadOnlyMemory<T> Current { get { throw null; } }
+            public bool MoveNext() { throw null; }
+        }
+    }
+    public abstract partial class ReadOnlySequenceSegment<T>
+    {
+        protected ReadOnlySequenceSegment() { }
+        public System.ReadOnlyMemory<T> Memory { get { throw null; } protected set { } }
+        public System.Buffers.ReadOnlySequenceSegment<T> Next { get { throw null; } protected set { } }
+        public long RunningIndex { get { throw null; } protected set { } }
     }
     public delegate void ReadOnlySpanAction<T, in TArg>(System.ReadOnlySpan<T> span, TArg arg);
     public delegate void SpanAction<T, in TArg>(System.Span<T> span, TArg arg);

--- a/netstandard/ref/System.Runtime.InteropServices.cs
+++ b/netstandard/ref/System.Runtime.InteropServices.cs
@@ -855,6 +855,12 @@ namespace System.Runtime.InteropServices
         public SEHException(string message, System.Exception inner) { }
         public virtual bool CanResume() { throw null; }
     }
+    public static partial class SequenceMarshal
+    {
+        public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> segment) { segment = default(System.ArraySegment<T>); throw null; }
+        public static bool TryGetReadOnlyMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ReadOnlyMemory<T> memory) { memory = default(System.ReadOnlyMemory<T>); throw null; }
+        public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.ReadOnlySequenceSegment<T> startSegment, out int startIndex, out System.Buffers.ReadOnlySequenceSegment<T> endSegment, out int endIndex) { startSegment = default(System.Buffers.ReadOnlySequenceSegment<T>); startIndex = default(int); endSegment = default(System.Buffers.ReadOnlySequenceSegment<T>); endIndex = default(int); throw null; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false)]
     public sealed partial class StructLayoutAttribute : System.Attribute
     {

--- a/netstandard/ref/System.cs
+++ b/netstandard/ref/System.cs
@@ -3489,6 +3489,19 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static bool TryParse(string s, out System.SByte result) { result = default(sbyte); throw null; }
     }
+    public readonly partial struct SequencePosition : System.IEquatable<System.SequencePosition>
+    {
+        public SequencePosition(object @object, int integer) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.SequencePosition other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public int GetInteger() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public object GetObject() { throw null; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4124), Inherited=false)]
     public sealed partial class SerializableAttribute : System.Attribute
     {

--- a/netstandard/src/GenApi.exclude.net461.txt
+++ b/netstandard/src/GenApi.exclude.net461.txt
@@ -8,6 +8,8 @@ T:System.Buffers.MemoryHandle
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
 T:System.Buffers.OperationStatus
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -67,6 +69,7 @@ T:System.Runtime.CompilerServices.RuntimeFeature
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.CompilerServices.ValueTaskAwaiter`1
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Runtime.Serialization.DataContractSerializerExtensions
 T:System.Runtime.Serialization.ISerializationSurrogateProvider
 T:System.Security.Cryptography.AesCng
@@ -82,6 +85,7 @@ T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
 T:System.Security.SecureStringMarshal
+T:System.SequencePosition
 T:System.Span`1
 T:System.StringNormalizationExtensions
 T:System.Threading.PreAllocatedOverlapped

--- a/netstandard/src/GenApi.exclude.xamarin.android.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.android.txt
@@ -6,6 +6,8 @@ T:System.Buffers.IMemoryOwner`1
 T:System.Buffers.IPinnable
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -43,12 +45,14 @@ T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder
 T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Security.Cryptography.CryptographicOperations
 T:System.Security.Cryptography.ECDiffieHellman
 T:System.Security.Cryptography.X509Certificates.CertificateRequest
 T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
+T:System.SequencePosition
 T:System.Span`1
 T:System.Threading.Tasks.Sources.IValueTaskSource
 T:System.Threading.Tasks.Sources.IValueTaskSource`1

--- a/netstandard/src/GenApi.exclude.xamarin.ios.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.ios.txt
@@ -6,6 +6,8 @@ T:System.Buffers.IMemoryOwner`1
 T:System.Buffers.IPinnable
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -49,12 +51,14 @@ T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder
 T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Security.Cryptography.CryptographicOperations
 T:System.Security.Cryptography.ECDiffieHellman
 T:System.Security.Cryptography.X509Certificates.CertificateRequest
 T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
+T:System.SequencePosition
 T:System.Span`1
 T:System.Threading.Tasks.Sources.IValueTaskSource
 T:System.Threading.Tasks.Sources.IValueTaskSource`1

--- a/netstandard/src/GenApi.exclude.xamarin.mac.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.mac.txt
@@ -6,6 +6,8 @@ T:System.Buffers.IMemoryOwner`1
 T:System.Buffers.IPinnable
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -49,12 +51,14 @@ T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder
 T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Security.Cryptography.CryptographicOperations
 T:System.Security.Cryptography.ECDiffieHellman
 T:System.Security.Cryptography.X509Certificates.CertificateRequest
 T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
+T:System.SequencePosition
 T:System.Span`1
 T:System.Threading.Tasks.Sources.IValueTaskSource
 T:System.Threading.Tasks.Sources.IValueTaskSource`1

--- a/netstandard/src/GenApi.exclude.xamarin.tvos.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.tvos.txt
@@ -6,6 +6,8 @@ T:System.Buffers.IMemoryOwner`1
 T:System.Buffers.IPinnable
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -49,12 +51,14 @@ T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder
 T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Security.Cryptography.CryptographicOperations
 T:System.Security.Cryptography.ECDiffieHellman
 T:System.Security.Cryptography.X509Certificates.CertificateRequest
 T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
+T:System.SequencePosition
 T:System.Span`1
 T:System.Threading.Tasks.Sources.IValueTaskSource
 T:System.Threading.Tasks.Sources.IValueTaskSource`1

--- a/netstandard/src/GenApi.exclude.xamarin.watchos.txt
+++ b/netstandard/src/GenApi.exclude.xamarin.watchos.txt
@@ -6,6 +6,8 @@ T:System.Buffers.IMemoryOwner`1
 T:System.Buffers.IPinnable
 T:System.Buffers.MemoryManager`1
 T:System.Buffers.MemoryPool`1
+T:System.Buffers.ReadOnlySequence`1
+T:System.Buffers.ReadOnlySequenceSegment`1
 T:System.Buffers.ReadOnlySpanAction`2
 T:System.Buffers.SpanAction`2
 T:System.Buffers.StandardFormat
@@ -49,12 +51,14 @@ T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder
 T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable
 T:System.Runtime.CompilerServices.ValueTaskAwaiter
 T:System.Runtime.InteropServices.MemoryMarshal
+T:System.Runtime.InteropServices.SequenceMarshal
 T:System.Security.Cryptography.CryptographicOperations
 T:System.Security.Cryptography.ECDiffieHellman
 T:System.Security.Cryptography.X509Certificates.CertificateRequest
 T:System.Security.Cryptography.X509Certificates.DSACertificateExtensions
 T:System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder
 T:System.Security.Cryptography.X509Certificates.X509SignatureGenerator
+T:System.SequencePosition
 T:System.Span`1
 T:System.Threading.Tasks.Sources.IValueTaskSource
 T:System.Threading.Tasks.Sources.IValueTaskSource`1


### PR DESCRIPTION
This fixes #932.

[From @KrzysztofCwalina](https://github.com/dotnet/standard/pull/916#issuecomment-431922548):

> In general, I agree with being cautious about adding new exchange types without having them exposed in many NetStandard (NS) APIs. But ReadOnlySequence seems to be simple enough and well tested in the context of Kestrel and Pipelines that I would add it to NS 2.1. We are in a process of building many APIs that depend on ROS and not having the exchange type in NS 2.1 (and relying on portable oob package) will make the system more fragile. Also, there are some libraries (e.g. Azure SDK) that try to minimize dependencies to types not in NS.