### PR TITLE
Add capability APIs for RefEmit and JIT

### DIFF
--- a/netstandard/ref/System.Runtime.CompilerServices.cs
+++ b/netstandard/ref/System.Runtime.CompilerServices.cs
@@ -499,6 +499,8 @@ namespace System.Runtime.CompilerServices
     public static partial class RuntimeFeature
     {
         public const string PortablePdb = "PortablePdb";
+        public static bool IsDynamicCodeSupported { get { throw null; } }
+        public static bool IsDynamicCodeCompiled { get { throw null; } }
         public static bool IsSupported(string feature) { throw null; }
     }
     public static partial class RuntimeHelpers


### PR DESCRIPTION
This fixes #832.

We've just approved the capability API for .NET Core that will expose this capability (https://github.com/dotnet/corefx/issues/29258).

This is a rare instance where the API has actually not shipped that we want to standardize. So strictly speaking, this is violating our [inclusion principles](https://github.com/dotnet/standard/blob/master/docs/governance/README.md#inclusion-principles) but it seems the opportunity loss seems high for what amounts to be a simple API.