### PR TITLE
Make sure Signing target finds packages to sign

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\Directory.Build.props')" Project="..\Directory.Build.props" />
   <ItemGroup>
-    <ItemsToSign Include="$(PackageOutputPath)**\*.nupkg" />
+  	<!-- TODO - change this location once Packages get outputted to the artifacts dir -->
+    <ItemsToSign Include="$(PackageOutputRoot)$(ConfigurationGroup)/**/*.nupkg" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will fix a build error where we can't find any packages to sign. The problem was caused by me moving the `PackageOutputPath` property from `Directory.Build.props` to `Directory.Build.targets`, which was a workaround to allow us to continue outputting packages to the bin dir while using Arcade's packaging tasks. Once we're outputting packages to `artifacts`, we can revert this PR.

CC @danmosemsft @JohnTortugo