### PR TITLE
Fix _SignType, Variable Groups in pipebuild

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -7,6 +7,8 @@ pr:
 variables:
   - name: _TeamName
     value: DotNetCore
+  - name: _BuildConfig 
+    value: Release
 
 jobs:
 - template: /eng/common/templates/jobs/jobs.yml
@@ -28,12 +30,10 @@ jobs:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: dotnet-internal-temp
       variables:
-      - name: _BuildConfig 
-        value: Release
-      - group: DotNet-Blob-Feed
-      - group: DotNet-Symbol-Server-Pats
       # Enable signing for internal, non-PR builds
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - group: DotNet-Blob-Feed
+        - group: DotNet-Symbol-Server-Pats
         - name: _BuildArgs
           value: /p:SignType=Real
             /p:DotNetSignType=Real
@@ -67,8 +67,6 @@ jobs:
         pool: 
           name: Hosted Ubuntu 1604
         variables:
-        - name: _BuildConfig 
-          value: Release
         - name: _SignType
           value: Test
         steps:
@@ -85,8 +83,6 @@ jobs:
         pool: 
           name: Hosted macOS
         variables:
-        - name: _BuildConfig 
-          value: Release
         - name: _SignType
           value: Test
         steps:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -34,6 +34,8 @@ jobs:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-Blob-Feed
         - group: DotNet-Symbol-Server-Pats
+        - name: _SignType
+          value: Real
         - name: _BuildArgs
           value: /p:SignType=Real
             /p:DotNetSignType=Real
@@ -51,6 +53,8 @@ jobs:
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _BuildArgs
           value: /p:SignType=Test
+        - name: _SignType
+          value: Test
       steps:
       - checkout: self
         clean: true

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -37,8 +37,8 @@ jobs:
         - name: _SignType
           value: Real
         - name: _BuildArgs
-          value: /p:SignType=Real
-            /p:DotNetSignType=Real
+          value: /p:SignType=$(_SignType)
+            /p:DotNetSignType=$(_SignType)
             /p:MicroBuild_SigningEnabled=true 
             /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
             /p:TeamName=$(_TeamName)
@@ -51,10 +51,10 @@ jobs:
         - name: _OfficialBuildIdArgs
       # else
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _BuildArgs
-          value: /p:SignType=Test
         - name: _SignType
           value: Test
+        - name: _BuildArgs
+          value: /p:SignType=$(_SignType)
       steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
This PR makes it so that we only access secrets in internal builds, and passes _SignType to the Windows builds.

@chcosta PTAL