### PR TITLE
Don't reference FeedTasksPackage

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -14,9 +14,6 @@
 
   <!-- Package versions used as toolsets --> 
   <PropertyGroup> 
-    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage> 
-    <FeedTasksPackageVersion>3.0.0-preview1-03224-03</FeedTasksPackageVersion> 
-
     <BuildToolsPackage>microsoft.dotnet.buildtools</BuildToolsPackage>
     <BuildToolsPackageVersion>3.0.0-preview1-03402-01</BuildToolsPackageVersion>
   </PropertyGroup> 
@@ -38,11 +35,6 @@
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
     </DependencyBuildInfo>    
 
-    <XmlUpdateStep Include="BuildTools">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>FeedTasksPackageVersion</ElementName>
-      <PackageId>$(FeedTasksPackage)</PackageId>
-    </XmlUpdateStep>
     <UpdateStep Include="BuildTools">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>BuildToolsPackageVersion</ElementName>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -11,7 +11,6 @@
   <Import Project="$(MSBuildThisFileDirectory)..\dependencies.props" />
   <ItemGroup>
     <PackageReference Include="$(BuildToolsPackage)" Version="$(BuildToolsPackageVersion)" />
-    <PackageReference Include="$(FeedTasksPackage)" Version="$(FeedTasksPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />

--- a/publish.msbuild
+++ b/publish.msbuild
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <Import Project="Directory.Build.targets" />
 
-  <Import Project="$(NuGetPackageRoot)/$(FeedTasksPackage)/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
-
   <PropertyGroup>
      <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>
      <SymbolsPackagesPattern>$(PackageOutputRoot)**\*.symbols.nupkg</SymbolsPackagesPattern>


### PR DESCRIPTION
Arcade already restores this package when trying to publish: https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj#L49

Since the default version in arcade is currently `2.2-xxx` (https://github.com/dotnet/arcade/blob/069237d9a7e83bed62c9f664228125b95ddf91f6/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props#L71), the build would fail when trying to import files from that package, since only the 3.0.0 version was getting restored: https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L30

CC @safern you'll want to make a similar change in CoreFx if you plan on doing Arcade publishing

@chcosta PTAL