### PR TITLE
Output packages into Artifacts dir

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,14 +11,6 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <!-- In order for packages to continue going into the bin directory, these need to be set after we import Sdk.targets.
-       Once we output everything to 'artifacts', we can move these back to Directory.Build.props -->
-  <PropertyGroup>
-    <PackagesBasePath>$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
-    <PackageOutputPath>$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>
-    <SymbolPackageOutputPath>$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!--
     Hack workaround to skip the GenerateCompiledExpressionsTempFile target in

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition="Exists('..\Directory.Build.props')" Project="..\Directory.Build.props" />
-  <ItemGroup>
-  	<!-- TODO - change this location once Packages get outputted to the artifacts dir -->
-    <ItemsToSign Include="$(PackageOutputRoot)$(ConfigurationGroup)/**/*.nupkg" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
This outputs packages into `ArtifactsPackagesDir`, so that Arcade can easily find them for signing & publishing (with this, we no longer need a custom `Signing.props` to specify where our packages live).

@chcosta @ericstj PTAL

Should fix the build error in https://dnceng.visualstudio.com/internal/_build/results?buildId=52052