### PR TITLE
Sync .NET Standard's RefEmit with .NET Framework

### DIFF
--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -455,7 +455,8 @@ namespace System.Reflection.Emit
         public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw null; } }
         public string Signature { get { throw null; } }
 //CAS   public void AddDeclarativeSecurity(System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { }
-        public void CreateMethodBody(byte[] il, int count) { }
+//      Excluded because this is a poorly designed API and it is virtually unused. The replacement is SetMethodBody.
+//      public void CreateMethodBody(byte[] il, int count) { }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw null; }
         public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string strParamName) { throw null; }
         public override bool Equals(object obj) { throw null; }

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -455,8 +455,7 @@ namespace System.Reflection.Emit
         public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw null; } }
         public string Signature { get { throw null; } }
 //CAS   public void AddDeclarativeSecurity(System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { }
-//      Excluded because this is a poorly designed API and it is virtually unused. The replacement is SetMethodBody.
-//      public void CreateMethodBody(byte[] il, int count) { }
+        public void CreateMethodBody(byte[] il, int count) { }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw null; }
         public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string strParamName) { throw null; }
         public override bool Equals(object obj) { throw null; }

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -226,7 +226,7 @@ namespace System.Reflection.Emit
         public void SetRaiseMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
         public void SetRemoveOnMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
     }
-    public partial struct EventToken
+    public readonly partial struct EventToken : System.IEquatable<EventToken>
     {
         public static readonly System.Reflection.Emit.EventToken Empty;
         public int Token { get { throw null; } }
@@ -274,7 +274,7 @@ namespace System.Reflection.Emit
         public void SetOffset(int iOffset) { }
         public override void SetValue(object obj, object val, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Globalization.CultureInfo culture) { }
     }
-    public partial struct FieldToken
+    public readonly partial struct FieldToken : System.IEquatable<FieldToken>
     {
         public static readonly System.Reflection.Emit.FieldToken Empty;
         public int Token { get { throw null; } }
@@ -494,7 +494,7 @@ namespace System.Reflection.Emit
 //      public const int JitOnDemand = 0;
 //      public static void SwapMethodBody(System.Type cls, int methodtoken, System.IntPtr rgIL, int methodSize, int flags) { }
 //  }
-    public partial struct MethodToken
+    public readonly partial struct MethodToken : System.IEquatable<MethodToken>
     {
         public static readonly System.Reflection.Emit.MethodToken Empty;
         public int Token { get { throw null; } }
@@ -866,7 +866,7 @@ namespace System.Reflection.Emit
 //      [System.ObsoleteAttribute("An alternate API is available: Emit the MarshalAs custom attribute instead. https://go.microsoft.com/fwlink/?linkid=14202")]
 //      public virtual void SetMarshal(System.Reflection.Emit.UnmanagedMarshal unmanagedMarshal) { }
     }
-    public partial struct ParameterToken
+    public readonly partial struct ParameterToken : System.IEquatable<ParameterToken>
     {
         public static readonly System.Reflection.Emit.ParameterToken Empty;
         public int Token { get { throw null; } }
@@ -912,7 +912,7 @@ namespace System.Reflection.Emit
         public override void SetValue(object obj, object value, object[] index) { }
         public override void SetValue(object obj, object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture) { }
     }
-    public partial struct PropertyToken
+    public readonly partial struct PropertyToken : System.IEquatable<PropertyToken>
     {
         public static readonly System.Reflection.Emit.PropertyToken Empty;
         public int Token { get { throw null; } }
@@ -946,7 +946,7 @@ namespace System.Reflection.Emit
         public byte[] GetSignature() { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial struct SignatureToken
+    public readonly partial struct SignatureToken : System.IEquatable<SignatureToken>
     {
         public static readonly System.Reflection.Emit.SignatureToken Empty;
         public int Token { get { throw null; } }
@@ -988,7 +988,7 @@ namespace System.Reflection.Emit
         Varpop = 26,
         Varpush = 27,
     }
-    public partial struct StringToken
+    public readonly partial struct StringToken : System.IEquatable<StringToken>
     {
         public int Token { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1112,7 +1112,7 @@ namespace System.Reflection.Emit
         public void SetParent(System.Type parent) { }
         public override string ToString() { throw null; }
     }
-    public partial struct TypeToken
+    public readonly partial struct TypeToken : System.IEquatable<TypeToken>
     {
         public static readonly System.Reflection.Emit.TypeToken Empty;
         public int Token { get { throw null; } }

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -10,6 +10,8 @@ namespace System.Reflection.Emit
         public override string FullName { get { throw null; } }
         public override bool IsDynamic { get { throw null; } }
         public override System.Reflection.Module ManifestModule { get { throw null; } }
+        public void AddResourceFile(string name, string fileName) { }
+        public void AddResourceFile(string name, string fileName, System.Reflection.ResourceAttributes attribute) { }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access) { throw null; }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access, System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> assemblyAttributes) { throw null; }
         public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name) { throw null; }
@@ -17,6 +19,12 @@ namespace System.Reflection.Emit
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, bool emitSymbolInfo) { throw null; }
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, string fileName) { throw null; }
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, string fileName, bool emitSymbolInfo) { throw null; }
+        public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName) { throw null; }
+        public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName, System.Reflection.ResourceAttributes attribute) { throw null; }
+        public void DefineUnmanagedResource(byte[] resource) { }
+        public void DefineUnmanagedResource(string resourceFileName) { }
+        public void DefineVersionInfoResource() { }
+        public void DefineVersionInfoResource(string product, string productVersion, string company, string copyright, string trademark) { }
         public override bool Equals(object obj) { throw null; }
         public System.Reflection.Emit.ModuleBuilder GetDynamicModule(string name) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -28,10 +36,13 @@ namespace System.Reflection.Emit
 //      public void Save(string assemblyFileName, System.Reflection.PortableExecutableKinds portableExecutableKind, System.Reflection.ImageFileMachine imageFileMachine) { }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
+        public void SetEntryPoint(System.Reflection.MethodInfo entryMethod) { }
+        public void SetEntryPoint(System.Reflection.MethodInfo entryMethod, System.Reflection.Emit.PEFileKinds fileKind) { }
     }
     [System.FlagsAttribute]
     public enum AssemblyBuilderAccess
     {
+        ReflectionOnly = 6,
         Run = 1,
         RunAndCollect = 9,
 //      Excluded because persistence of Ref Emit is only supported in .NET Framework
@@ -51,6 +62,7 @@ namespace System.Reflection.Emit
         public override System.Type ReflectedType { get { throw null; } }
 //      [System.ObsoleteAttribute("This property has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
 //      public System.Type ReturnType { get { throw null; } }
+        public string Signature { get { throw null; } }
 //CAS   public void AddDeclarativeSecurity(System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { }
         public System.Reflection.Emit.ParameterBuilder DefineParameter(int iSequence, System.Reflection.ParameterAttributes attributes, string strParamName) { throw null; }
         public override object[] GetCustomAttributes(bool inherit) { throw null; }
@@ -58,13 +70,16 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.ILGenerator GetILGenerator() { throw null; }
         public System.Reflection.Emit.ILGenerator GetILGenerator(int streamSize) { throw null; }
         public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw null; }
+        public System.Reflection.Module GetModule() { throw null; }
         public override System.Reflection.ParameterInfo[] GetParameters() { throw null; }
+        public System.Reflection.Emit.MethodToken GetToken() { throw null; }
         public override object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw null; }
         public override object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
         public void SetImplementationFlags(System.Reflection.MethodImplAttributes attributes) { }
+        public void SetMethodBody(byte[] il, int maxStack, byte[] localSignature, System.Collections.Generic.IEnumerable<System.Reflection.Emit.ExceptionHandler> exceptionHandlers, System.Collections.Generic.IEnumerable<int> tokenFixups) { }
 //      Excluded because we don't support generating with debug information.
 //      public void SetSymCustomAttribute(string name, byte[] data) { }
         public override string ToString() { throw null; }
@@ -75,6 +90,28 @@ namespace System.Reflection.Emit
         public CustomAttributeBuilder(System.Reflection.ConstructorInfo con, object[] constructorArgs, System.Reflection.FieldInfo[] namedFields, object[] fieldValues) { }
         public CustomAttributeBuilder(System.Reflection.ConstructorInfo con, object[] constructorArgs, System.Reflection.PropertyInfo[] namedProperties, object[] propertyValues) { }
         public CustomAttributeBuilder(System.Reflection.ConstructorInfo con, object[] constructorArgs, System.Reflection.PropertyInfo[] namedProperties, object[] propertyValues, System.Reflection.FieldInfo[] namedFields, object[] fieldValues) { }
+    }
+    public partial class DynamicILInfo
+    {
+        internal DynamicILInfo() { }
+        public System.Reflection.Emit.DynamicMethod DynamicMethod { get { throw null; } }
+        public int GetTokenFor(byte[] signature) { throw null; }
+        public int GetTokenFor(System.Reflection.Emit.DynamicMethod method) { throw null; }
+        public int GetTokenFor(System.RuntimeFieldHandle field) { throw null; }
+        public int GetTokenFor(System.RuntimeFieldHandle field, System.RuntimeTypeHandle contextType) { throw null; }
+        public int GetTokenFor(System.RuntimeMethodHandle method) { throw null; }
+        public int GetTokenFor(System.RuntimeMethodHandle method, System.RuntimeTypeHandle contextType) { throw null; }
+        public int GetTokenFor(System.RuntimeTypeHandle type) { throw null; }
+        public int GetTokenFor(string literal) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetCode(byte* code, int codeSize, int maxStackSize) { }
+        public void SetCode(byte[] code, int maxStackSize) { }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetExceptions(byte* exceptions, int exceptionsSize) { }
+        public void SetExceptions(byte[] exceptions) { }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetLocalSignature(byte* localSignature, int signatureSize) { }
+        public void SetLocalSignature(byte[] localSignature) { }
     }
     public sealed partial class DynamicMethod : System.Reflection.MethodInfo
     {
@@ -98,9 +135,11 @@ namespace System.Reflection.Emit
         public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw null; } }
         public sealed override System.Delegate CreateDelegate(System.Type delegateType) { throw null; }
         public sealed override System.Delegate CreateDelegate(System.Type delegateType, object target) { throw null; }
+        public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string parameterName) { throw null; }
         public override System.Reflection.MethodInfo GetBaseDefinition() { throw null; }
         public override object[] GetCustomAttributes(bool inherit) { throw null; }
         public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public System.Reflection.Emit.DynamicILInfo GetDynamicILInfo() { throw null; }
         public System.Reflection.Emit.ILGenerator GetILGenerator() { throw null; }
         public System.Reflection.Emit.ILGenerator GetILGenerator(int streamSize) { throw null; }
         public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw null; }
@@ -109,7 +148,7 @@ namespace System.Reflection.Emit
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public override string ToString() { throw null; }
     }
-    public sealed partial class EnumBuilder : System.Type
+    public sealed partial class EnumBuilder : System.Reflection.TypeInfo
     {
         internal EnumBuilder() { }
         public override System.Reflection.Assembly Assembly { get { throw null; } }
@@ -128,8 +167,10 @@ namespace System.Reflection.Emit
         public override string Namespace { get { throw null; } }
         public override System.Type ReflectedType { get { throw null; } }
         public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
+        public System.Reflection.Emit.TypeToken TypeToken { get { throw null; } }
         public System.Reflection.Emit.FieldBuilder UnderlyingField { get { throw null; } }
         public override System.Type UnderlyingSystemType { get { throw null; } }
+        public System.Type CreateType() { throw null; }
         public System.Reflection.TypeInfo CreateTypeInfo() { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineLiteral(string literalName, object literalValue) { throw null; }
         protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw null; }
@@ -175,11 +216,38 @@ namespace System.Reflection.Emit
     {
         internal EventBuilder() { }
         public void AddOtherMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
+        public System.Reflection.Emit.EventToken GetEventToken() { throw null; }
         public void SetAddOnMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
         public void SetRaiseMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
         public void SetRemoveOnMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
+    }
+    public partial struct EventToken
+    {
+        public static readonly System.Reflection.Emit.EventToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.EventToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw null; }
+    }
+    public partial struct ExceptionHandler : System.IEquatable<System.Reflection.Emit.ExceptionHandler>
+    {
+        public ExceptionHandler(int tryOffset, int tryLength, int filterOffset, int handlerOffset, int handlerLength, System.Reflection.ExceptionHandlingClauseOptions kind, int exceptionTypeToken) { throw null; }
+        public int ExceptionTypeToken { get { throw null; } }
+        public int FilterOffset { get { throw null; } }
+        public int HandlerLength { get { throw null; } }
+        public int HandlerOffset { get { throw null; } }
+        public System.Reflection.ExceptionHandlingClauseOptions Kind { get { throw null; } }
+        public int TryLength { get { throw null; } }
+        public int TryOffset { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.ExceptionHandler other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.ExceptionHandler left, System.Reflection.Emit.ExceptionHandler right) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.ExceptionHandler left, System.Reflection.Emit.ExceptionHandler right) { throw null; }
     }
     public sealed partial class FieldBuilder : System.Reflection.FieldInfo
     {
@@ -192,6 +260,7 @@ namespace System.Reflection.Emit
         public override System.Type ReflectedType { get { throw null; } }
         public override object[] GetCustomAttributes(bool inherit) { throw null; }
         public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public System.Reflection.Emit.FieldToken GetToken() { throw null; }
         public override object GetValue(object obj) { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public void SetConstant(object defaultValue) { }
@@ -201,6 +270,16 @@ namespace System.Reflection.Emit
 //      public void SetMarshal(System.Reflection.Emit.UnmanagedMarshal unmanagedMarshal) { }
         public void SetOffset(int iOffset) { }
         public override void SetValue(object obj, object val, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Globalization.CultureInfo culture) { }
+    }
+    public partial struct FieldToken
+    {
+        public static readonly System.Reflection.Emit.FieldToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.FieldToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.FieldToken a, System.Reflection.Emit.FieldToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.FieldToken a, System.Reflection.Emit.FieldToken b) { throw null; }
     }
     public enum FlowControl
     {
@@ -215,7 +294,7 @@ namespace System.Reflection.Emit
         Return = 7,
         Throw = 8,
     }
-    public sealed partial class GenericTypeParameterBuilder : System.Type
+    public sealed partial class GenericTypeParameterBuilder : System.Reflection.TypeInfo
     {
         internal GenericTypeParameterBuilder() { }
         public override System.Reflection.Assembly Assembly { get { throw null; } }
@@ -370,7 +449,9 @@ namespace System.Reflection.Emit
         public override System.Reflection.ParameterInfo ReturnParameter { get { throw null; } }
         public override System.Type ReturnType { get { throw null; } }
         public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw null; } }
+        public string Signature { get { throw null; } }
 //CAS   public void AddDeclarativeSecurity(System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { }
+        public void CreateMethodBody(byte[] il, int count) { }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw null; }
         public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string strParamName) { throw null; }
         public override bool Equals(object obj) { throw null; }
@@ -383,7 +464,9 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.ILGenerator GetILGenerator() { throw null; }
         public System.Reflection.Emit.ILGenerator GetILGenerator(int size) { throw null; }
         public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw null; }
+        public System.Reflection.Module GetModule() { throw null; }
         public override System.Reflection.ParameterInfo[] GetParameters() { throw null; }
+        public System.Reflection.Emit.MethodToken GetToken() { throw null; }
         public override object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public override System.Reflection.MethodInfo MakeGenericMethod(params System.Type[] typeArguments) { throw null; }
@@ -392,12 +475,30 @@ namespace System.Reflection.Emit
         public void SetImplementationFlags(System.Reflection.MethodImplAttributes attributes) { }
 //      [System.ObsoleteAttribute("An alternate API is available: Emit the MarshalAs custom attribute instead. https://go.microsoft.com/fwlink/?linkid=14202")]
 //      public void SetMarshal(System.Reflection.Emit.UnmanagedMarshal unmanagedMarshal) { }
+        public void SetMethodBody(byte[] il, int maxStack, byte[] localSignature, System.Collections.Generic.IEnumerable<System.Reflection.Emit.ExceptionHandler> exceptionHandlers, System.Collections.Generic.IEnumerable<int> tokenFixups) { }
         public void SetParameters(params System.Type[] parameterTypes) { }
         public void SetReturnType(System.Type returnType) { }
         public void SetSignature(System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { }
 //      Excluded because we don't support generating with debug information.
 //      public void SetSymCustomAttribute(string name, byte[] data) { }
         public override string ToString() { throw null; }
+    }
+    public sealed partial class MethodRental
+    {
+        internal MethodRental() { }
+        public const int JitImmediate = 1;
+        public const int JitOnDemand = 0;
+        public static void SwapMethodBody(System.Type cls, int methodtoken, System.IntPtr rgIL, int methodSize, int flags) { }
+    }
+    public partial struct MethodToken
+    {
+        public static readonly System.Reflection.Emit.MethodToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.MethodToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.MethodToken a, System.Reflection.Emit.MethodToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.MethodToken a, System.Reflection.Emit.MethodToken b) { throw null; }
     }
     public partial class ModuleBuilder : System.Reflection.Module
     {
@@ -413,6 +514,11 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineInitializedData(string name, byte[] data, System.Reflection.FieldAttributes attributes) { throw null; }
+        public void DefineManifestResource(string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) { }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
+        public System.Resources.IResourceWriter DefineResource(string name, string description) { throw null; }
+        public System.Resources.IResourceWriter DefineResource(string name, string description, System.Reflection.ResourceAttributes attribute) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent) { throw null; }
@@ -421,13 +527,29 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packingSize, int typesize) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Type[] interfaces) { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineUninitializedData(string name, int size, System.Reflection.FieldAttributes attributes) { throw null; }
+        public void DefineUnmanagedResource(byte[] resource) { }
+        public void DefineUnmanagedResource(string resourceFileName) { }
         public override bool Equals(object obj) { throw null; }
         public System.Reflection.MethodInfo GetArrayMethod(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw null; }
+        public System.Reflection.Emit.MethodToken GetArrayMethodToken(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw null; }
+        public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo con) { throw null; }
+        public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo constructor, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw null; }
+        public System.Reflection.Emit.FieldToken GetFieldToken(System.Reflection.FieldInfo field) { throw null; }
         public override int GetHashCode() { throw null; }
+        public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method) { throw null; }
+        public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw null; }
+        public System.Reflection.Emit.SignatureToken GetSignatureToken(byte[] sigBytes, int sigLength) { throw null; }
+        public System.Reflection.Emit.SignatureToken GetSignatureToken(System.Reflection.Emit.SignatureHelper sigHelper) { throw null; }
+        public System.Reflection.Emit.StringToken GetStringConstant(string str) { throw null; }
+        public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter() { throw null; }
+        public System.Reflection.Emit.TypeToken GetTypeToken(string name) { throw null; }
+        public System.Reflection.Emit.TypeToken GetTypeToken(System.Type type) { throw null; }
+        public bool IsTransient() { throw null; }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
 //      Excluded because we don't support generating with debug information.
 //      public void SetSymCustomAttribute(string name, byte[] data) { }
+        public void SetUserEntryPoint(System.Reflection.MethodInfo entryPoint) { }
     }
     public partial struct OpCode
     {
@@ -730,11 +852,28 @@ namespace System.Reflection.Emit
         public bool IsOut { get { throw null; } }
         public virtual string Name { get { throw null; } }
         public virtual int Position { get { throw null; } }
+        public virtual System.Reflection.Emit.ParameterToken GetToken() { throw null; }
         public virtual void SetConstant(object defaultValue) { }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
 //      [System.ObsoleteAttribute("An alternate API is available: Emit the MarshalAs custom attribute instead. https://go.microsoft.com/fwlink/?linkid=14202")]
 //      public virtual void SetMarshal(System.Reflection.Emit.UnmanagedMarshal unmanagedMarshal) { }
+    }
+    public partial struct ParameterToken
+    {
+        public static readonly System.Reflection.Emit.ParameterToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.ParameterToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw null; }
+    }
+    public enum PEFileKinds
+    {
+        ConsoleApplication = 2,
+        Dll = 1,
+        WindowApplication = 3,
     }
     public sealed partial class PropertyBuilder : System.Reflection.PropertyInfo
     {
@@ -745,6 +884,7 @@ namespace System.Reflection.Emit
         public override System.Type DeclaringType { get { throw null; } }
         public override System.Reflection.Module Module { get { throw null; } }
         public override string Name { get { throw null; } }
+        public System.Reflection.Emit.PropertyToken PropertyToken { get { throw null; } }
         public override System.Type PropertyType { get { throw null; } }
         public override System.Type ReflectedType { get { throw null; } }
         public void AddOtherMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { }
@@ -765,6 +905,16 @@ namespace System.Reflection.Emit
         public override void SetValue(object obj, object value, object[] index) { }
         public override void SetValue(object obj, object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture) { }
     }
+    public partial struct PropertyToken
+    {
+        public static readonly System.Reflection.Emit.PropertyToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.PropertyToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.PropertyToken a, System.Reflection.Emit.PropertyToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.PropertyToken a, System.Reflection.Emit.PropertyToken b) { throw null; }
+    }
     public sealed partial class SignatureHelper
     {
         internal SignatureHelper() { }
@@ -780,12 +930,24 @@ namespace System.Reflection.Emit
         public static System.Reflection.Emit.SignatureHelper GetLocalVarSigHelper(System.Reflection.Module mod) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.CallingConventions callingConvention, System.Type returnType) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.Module mod, System.Reflection.CallingConventions callingConvention, System.Type returnType) { throw null; }
+        public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.Module mod, System.Runtime.InteropServices.CallingConvention unmanagedCallConv, System.Type returnType) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] parameterTypes) { throw null; }
+        public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Runtime.InteropServices.CallingConvention unmanagedCallingConvention, System.Type returnType) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }
         public byte[] GetSignature() { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial struct SignatureToken
+    {
+        public static readonly System.Reflection.Emit.SignatureToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.SignatureToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.SignatureToken a, System.Reflection.Emit.SignatureToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.SignatureToken a, System.Reflection.Emit.SignatureToken b) { throw null; }
     }
     public enum StackBehaviour
     {
@@ -819,7 +981,16 @@ namespace System.Reflection.Emit
         Varpop = 26,
         Varpush = 27,
     }
-    public sealed partial class TypeBuilder : System.Type
+    public partial struct StringToken
+    {
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.StringToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.StringToken a, System.Reflection.Emit.StringToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.StringToken a, System.Reflection.Emit.StringToken b) { throw null; }
+    }
+    public sealed partial class TypeBuilder : System.Reflection.TypeInfo
     {
         internal TypeBuilder() { }
         public const int UnspecifiedTypeSize = 0;
@@ -850,6 +1021,7 @@ namespace System.Reflection.Emit
         public override System.Type ReflectedType { get { throw null; } }
         public int Size { get { throw null; } }
         public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
+        public System.Reflection.Emit.TypeToken TypeToken { get { throw null; } }
         public override System.Type UnderlyingSystemType { get { throw null; } }
 //CAS   public void AddDeclarativeSecurity(System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { }
         public void AddInterfaceImplementation(System.Type interfaceType) { }
@@ -876,6 +1048,9 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packSize) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packSize, int typeSize) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Type[] interfaces) { throw null; }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
         public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw null; }
         public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw null; }
@@ -929,6 +1104,16 @@ namespace System.Reflection.Emit
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
         public void SetParent(System.Type parent) { }
         public override string ToString() { throw null; }
+    }
+    public partial struct TypeToken
+    {
+        public static readonly System.Reflection.Emit.TypeToken Empty;
+        public int Token { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Reflection.Emit.TypeToken obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.Emit.TypeToken a, System.Reflection.Emit.TypeToken b) { throw null; }
+        public static bool operator !=(System.Reflection.Emit.TypeToken a, System.Reflection.Emit.TypeToken b) { throw null; }
     }
 //  [System.ObsoleteAttribute("An alternate API is available: Emit the MarshalAs custom attribute instead. https://go.microsoft.com/fwlink/?linkid=14202")]
 //  public sealed partial class UnmanagedMarshal

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -237,7 +237,7 @@ namespace System.Reflection.Emit
         public static bool operator ==(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw null; }
         public static bool operator !=(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw null; }
     }
-    public partial struct ExceptionHandler : System.IEquatable<System.Reflection.Emit.ExceptionHandler>
+    public readonly partial struct ExceptionHandler : System.IEquatable<System.Reflection.Emit.ExceptionHandler>
     {
         public ExceptionHandler(int tryOffset, int tryLength, int filterOffset, int handlerOffset, int handlerLength, System.Reflection.ExceptionHandlingClauseOptions kind, int exceptionTypeToken) { throw null; }
         public int ExceptionTypeToken { get { throw null; } }
@@ -417,7 +417,7 @@ namespace System.Reflection.Emit
         public virtual void ThrowException(System.Type excType) { }
         public virtual void UsingNamespace(string usingNamespace) { }
     }
-    public partial struct Label
+    public readonly partial struct Label : System.IEquatable<Label>
     {
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Emit.Label obj) { throw null; }
@@ -561,7 +561,7 @@ namespace System.Reflection.Emit
 //      public void SetSymCustomAttribute(string name, byte[] data) { }
         public void SetUserEntryPoint(System.Reflection.MethodInfo entryPoint) { }
     }
-    public partial struct OpCode
+    public readonly partial struct OpCode : System.IEquatable<OpCode>
     {
         public System.Reflection.Emit.FlowControl FlowControl { get { throw null; } }
         public string Name { get { throw null; } }

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -10,8 +10,9 @@ namespace System.Reflection.Emit
         public override string FullName { get { throw null; } }
         public override bool IsDynamic { get { throw null; } }
         public override System.Reflection.Module ManifestModule { get { throw null; } }
-        public void AddResourceFile(string name, string fileName) { }
-        public void AddResourceFile(string name, string fileName, System.Reflection.ResourceAttributes attribute) { }
+//      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public void AddResourceFile(string name, string fileName) { }
+//      public void AddResourceFile(string name, string fileName, System.Reflection.ResourceAttributes attribute) { }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access) { throw null; }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access, System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> assemblyAttributes) { throw null; }
         public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name) { throw null; }
@@ -518,7 +519,8 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineInitializedData(string name, byte[] data, System.Reflection.FieldAttributes attributes) { throw null; }
-        public void DefineManifestResource(string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) { }
+//      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public void DefineManifestResource(string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) { }
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
 //      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
@@ -876,12 +878,13 @@ namespace System.Reflection.Emit
         public static bool operator ==(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw null; }
         public static bool operator !=(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw null; }
     }
-    public enum PEFileKinds
-    {
-        ConsoleApplication = 2,
-        Dll = 1,
-        WindowApplication = 3,
-    }
+//  Excluded because PEFileKinds is only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//  public enum PEFileKinds
+//  {
+//      ConsoleApplication = 2,
+//      Dll = 1,
+//      WindowApplication = 3,
+//  }
     public sealed partial class PropertyBuilder : System.Reflection.PropertyInfo
     {
         internal PropertyBuilder() { }

--- a/netstandard/ref/System.Reflection.Emit.cs
+++ b/netstandard/ref/System.Reflection.Emit.cs
@@ -19,12 +19,13 @@ namespace System.Reflection.Emit
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, bool emitSymbolInfo) { throw null; }
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, string fileName) { throw null; }
 //      public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name, string fileName, bool emitSymbolInfo) { throw null; }
-        public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName) { throw null; }
-        public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName, System.Reflection.ResourceAttributes attribute) { throw null; }
-        public void DefineUnmanagedResource(byte[] resource) { }
-        public void DefineUnmanagedResource(string resourceFileName) { }
-        public void DefineVersionInfoResource() { }
-        public void DefineVersionInfoResource(string product, string productVersion, string company, string copyright, string trademark) { }
+//      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName) { throw null; }
+//      public System.Resources.IResourceWriter DefineResource(string name, string description, string fileName, System.Reflection.ResourceAttributes attribute) { throw null; }
+//      public void DefineUnmanagedResource(byte[] resource) { }
+//      public void DefineUnmanagedResource(string resourceFileName) { }
+//      public void DefineVersionInfoResource() { }
+//      public void DefineVersionInfoResource(string product, string productVersion, string company, string copyright, string trademark) { }
         public override bool Equals(object obj) { throw null; }
         public System.Reflection.Emit.ModuleBuilder GetDynamicModule(string name) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -37,12 +38,14 @@ namespace System.Reflection.Emit
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
         public void SetEntryPoint(System.Reflection.MethodInfo entryMethod) { }
-        public void SetEntryPoint(System.Reflection.MethodInfo entryMethod, System.Reflection.Emit.PEFileKinds fileKind) { }
+//      Excluded because fileKind is only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public void SetEntryPoint(System.Reflection.MethodInfo entryMethod, System.Reflection.Emit.PEFileKinds fileKind) { }
     }
     [System.FlagsAttribute]
     public enum AssemblyBuilderAccess
     {
-        ReflectionOnly = 6,
+//      Excluded because ReflectionOnlyLoad is only supported in .NET Framework.
+//      ReflectionOnly = 6,
         Run = 1,
         RunAndCollect = 9,
 //      Excluded because persistence of Ref Emit is only supported in .NET Framework
@@ -483,13 +486,14 @@ namespace System.Reflection.Emit
 //      public void SetSymCustomAttribute(string name, byte[] data) { }
         public override string ToString() { throw null; }
     }
-    public sealed partial class MethodRental
-    {
-        internal MethodRental() { }
-        public const int JitImmediate = 1;
-        public const int JitOnDemand = 0;
-        public static void SwapMethodBody(System.Type cls, int methodtoken, System.IntPtr rgIL, int methodSize, int flags) { }
-    }
+//  Excluded because it's a broken API from .NET Framework v1. Not supported anywhere else.
+//  public sealed partial class MethodRental
+//  {
+//      internal MethodRental() { }
+//      public const int JitImmediate = 1;
+//      public const int JitOnDemand = 0;
+//      public static void SwapMethodBody(System.Type cls, int methodtoken, System.IntPtr rgIL, int methodSize, int flags) { }
+//  }
     public partial struct MethodToken
     {
         public static readonly System.Reflection.Emit.MethodToken Empty;
@@ -517,8 +521,9 @@ namespace System.Reflection.Emit
         public void DefineManifestResource(string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) { }
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw null; }
-        public System.Resources.IResourceWriter DefineResource(string name, string description) { throw null; }
-        public System.Resources.IResourceWriter DefineResource(string name, string description, System.Reflection.ResourceAttributes attribute) { throw null; }
+//      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public System.Resources.IResourceWriter DefineResource(string name, string description) { throw null; }
+//      public System.Resources.IResourceWriter DefineResource(string name, string description, System.Reflection.ResourceAttributes attribute) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent) { throw null; }
@@ -527,8 +532,9 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packingSize, int typesize) { throw null; }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Type[] interfaces) { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineUninitializedData(string name, int size, System.Reflection.FieldAttributes attributes) { throw null; }
-        public void DefineUnmanagedResource(byte[] resource) { }
-        public void DefineUnmanagedResource(string resourceFileName) { }
+//      Excluded because they are only meaningful to assemblies that are written to disk, which we only support in .NET Framework.
+//      public void DefineUnmanagedResource(byte[] resource) { }
+//      public void DefineUnmanagedResource(string resourceFileName) { }
         public override bool Equals(object obj) { throw null; }
         public System.Reflection.MethodInfo GetArrayMethod(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public System.Reflection.Emit.MethodToken GetArrayMethodToken(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw null; }
@@ -541,7 +547,8 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.SignatureToken GetSignatureToken(byte[] sigBytes, int sigLength) { throw null; }
         public System.Reflection.Emit.SignatureToken GetSignatureToken(System.Reflection.Emit.SignatureHelper sigHelper) { throw null; }
         public System.Reflection.Emit.StringToken GetStringConstant(string str) { throw null; }
-        public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter() { throw null; }
+//      Excluded because we don't support generating with debug information.
+//      public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter() { throw null; }
         public System.Reflection.Emit.TypeToken GetTypeToken(string name) { throw null; }
         public System.Reflection.Emit.TypeToken GetTypeToken(System.Type type) { throw null; }
         public bool IsTransient() { throw null; }

--- a/netstandard/ref/System.cs
+++ b/netstandard/ref/System.cs
@@ -2744,7 +2744,7 @@ namespace System
         public Lazy(System.Func<T> valueFactory, TMetadata metadata) { }
         public Lazy(System.Func<T> valueFactory, TMetadata metadata, bool isThreadSafe) { }
         public Lazy(System.Func<T> valueFactory, TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
-        public TMetadata Metadata { throw null; }
+        public TMetadata Metadata { get { throw null; } }
     }
     public partial class LdapStyleUriParser : System.UriParser
     {


### PR DESCRIPTION
Fixes #987

The point of the sync is to get increase parity with .NET Framework and thus making it easier to port more existing code to .NET Standard 2.1 (or any platform implementing it).