### PR TITLE
Move build output from `bin` to `artifacts`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,10 +19,8 @@
     <SourceDir>$(ProjectDir)src\</SourceDir>
 
     <!-- Output directories -->
-    <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
-    <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
-    <RootIntermediateOutputPath Condition="'$(RootIntermediateOutputPath)'==''">$(BaseIntermediateOutputPath)</RootIntermediateOutputPath>
+    <BinDir>$(ProjectDir)artifacts\bin\</BinDir>
+    <RootIntermediateOutputPath>$(ProjectDir)artifacts\obj\</RootIntermediateOutputPath>
 
     <PackageOutputRoot Condition="'$(PackageOutputRoot)'=='' and '$(NonShippingPackage)' == 'true'">$(BinDir)packages_noship/</PackageOutputRoot>
     <PackageOutputRoot Condition="'$(PackageOutputRoot)'==''">$(BinDir)packages/</PackageOutputRoot>
@@ -177,6 +175,9 @@
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Suppress preview message as we are usually using preview SDK versions. -->
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <!-- Set up handling of build warnings -->
@@ -190,12 +191,10 @@
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
 
-    <BaseOutputPath>$(BinDir)</BaseOutputPath>
     <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
-    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
+    <OutputPath>$(OutputPath)$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
 
-    <IntermediateOutputRootPath>$(BaseIntermediateOutputPath)$(OSPlatformConfig)/</IntermediateOutputRootPath>
-    <IntermediateOutputPath>$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
+    <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/</TestPath>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -191,8 +191,7 @@
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
 
-    <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
-    <OutputPath>$(OutputPath)$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
+    <OutputPath>$(OutputPath)$(TargetOutputRelPath)</OutputPath>
 
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetOutputRelPath)</IntermediateOutputPath>
 

--- a/apicompat/Directory.Build.props
+++ b/apicompat/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <ContainsPackageReferences>true</ContainsPackageReferences>
-    <RestoredRefRootPath>$(ObjDir)CompatShims/ref/</RestoredRefRootPath>
+    <RestoredRefRootPath>$(ArtifactsObjDir)CompatShims/ref/</RestoredRefRootPath>
   </PropertyGroup>
 </Project>

--- a/apicompat/apicompat.proj
+++ b/apicompat/apicompat.proj
@@ -4,9 +4,9 @@
 
   <PropertyGroup>
     <RestoredRefPath>$(IntermediateOutputPath)CompatShims/ref/</RestoredRefPath>
-    <NetstandardRefPath>$(BinDir)ref/netstandard/2.0.0.0/</NetstandardRefPath>
-    <NetstandardShimsPath>$(BinDir)shims/netstandard</NetstandardShimsPath>
-    <NetfxShimsPath>$(BinDir)shims/netfx</NetfxShimsPath>
+    <NetstandardRefPath>$(ArtifactsBinDir)netstandard/ref/netstandard/2.0.0.0/</NetstandardRefPath>
+    <NetstandardShimsPath>$(ArtifactsBinDir)shims/netstandard</NetstandardShimsPath>
+    <NetfxShimsPath>$(ArtifactsBinDir)shims/netfx</NetfxShimsPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build.proj
+++ b/build.proj
@@ -52,7 +52,9 @@
 
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean">
-    <RemoveDir Directories="$(ArtifactsDir)" />
+    <RemoveDir Directories="$(ArtifactsObjDir)" />
+    <RemoveDir Directories="$(ArtifactsBinDir)" />
+    <RemoveDir Directories="$(ArtifactsPackagesDir)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/build.proj
+++ b/build.proj
@@ -52,8 +52,7 @@
 
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean">
-    <RemoveDir Directories="$(ArtifactsObjDir)" />
-    <RemoveDir Directories="$(ArtifactsBinDir)" />
+    <RemoveDir Directories="$(ArtifactsDir)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/build.proj
+++ b/build.proj
@@ -24,6 +24,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_RestoreProjects)" />
+    <MSBuild Projects="Microsoft.Packaging.Tools.Trimming/tasks/Microsoft.Packaging.Tools.Trimming.Tasks.csproj" Targets="Restore" />
   </Target>
 
   <Target Name="BuildManaged">
@@ -52,7 +53,8 @@
 
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir)" />
+    <RemoveDir Directories="$(ArtifactsObjDir)" />
+    <RemoveDir Directories="$(ArtifactsBinDir)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/build.proj
+++ b/build.proj
@@ -24,7 +24,6 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_RestoreProjects)" />
-    <MSBuild Projects="Microsoft.Packaging.Tools.Trimming/tasks/Microsoft.Packaging.Tools.Trimming.Tasks.csproj" Targets="Restore" />
   </Target>
 
   <Target Name="BuildManaged">

--- a/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/netstandard/pkg/NETStandard.Library.pkgproj
@@ -50,7 +50,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <OutDir>$(BaseOutputPath)shims/$(ShimRelOutputPath)</OutDir>
+    <OutDir>$(ArtifactsBinDir)shims/$(ShimRelOutputPath)</OutDir>
   </PropertyGroup>
 
 </Project>

--- a/netstandard/pkg/shims/Directory.Build.targets
+++ b/netstandard/pkg/shims/Directory.Build.targets
@@ -27,7 +27,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <OutDir>$(BaseOutputPath)shims/$(ShimRelOutputPath)</OutDir>
+    <OutDir>$(ArtifactsBinDir)shims/$(ShimRelOutputPath)</OutDir>
     <GenerateProjectSpecificOutputFolder>false</GenerateProjectSpecificOutputFolder>
     <NoWarn>$(NoWarn);0618</NoWarn>
     <!-- Leave TargetPath empty so it can be set by Microsoft.Common.CurrentVersion.targets -->

--- a/platforms/Directory.Build.props
+++ b/platforms/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Condition="Exists('..\Directory.Build.props')" Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-  	<OutDir>$(BaseOutputPath)ref/$(TargetGroup)/</OutDir>
+  	<OutDir>$(ArtifactsBinDir)ref/$(TargetGroup)/</OutDir>
     <IsReferenceAssembly>true</IsReferenceAssembly>
     <LangVersion>7.2</LangVersion>
     <TargetFramework>net461</TargetFramework>

--- a/platforms/Directory.Build.targets
+++ b/platforms/Directory.Build.targets
@@ -19,7 +19,7 @@
   <Import Condition="Exists('..\Directory.Build.targets')" Project="..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <OutDir>$(BaseOutputPath)ref/$(TargetGroup)/</OutDir>
+    <OutDir>$(ArtifactsBinDir)ref/$(TargetGroup)/</OutDir>
     <TargetPath>$(TargetPathValue)</TargetPath>
   </PropertyGroup>
 


### PR DESCRIPTION
This allows Arcade to take over in deciding where we output our build artifacts, so we no longer have everything going into the `bin` dir. I don't believe there's anywhere else that explicitly depends on Standard's `bin` dir, but please let me know if you think I'm missing anything.

@ericstj @ViktorHofer @weshaggard PTAL

@danmosemsft CC