### PR TITLE
Enable publishing to build-assets registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,8 @@ jobs:
         - group: DotNet-Symbol-Server-Pats
         - name: _SignType
           value: Real
+        - name: _DotNetPublishToBlobFeed
+          value: true
         - name: _BuildArgs
           value: /p:SignType=$(_SignType)
             /p:DotNetSignType=$(_SignType)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,7 @@ jobs:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
     enablePublishTestResults: false
-    # TODO - set 'enablePublishBuildAssets: true' once we're publishing output to the 'artifacts' dir
-    enablePublishBuildAssets: false
+    enablePublishBuildAssets: true
     enableTelemetry: true
     helixRepo: dotnet/standard
     jobs:

--- a/build.proj
+++ b/build.proj
@@ -59,5 +59,8 @@
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
+  <!-- Define an empty Execute target for Arcade's build.proj to find -->
+  <Target Name="Execute" />
+
 </Project>
 


### PR DESCRIPTION
Now that Standard is placing build output in `artifacts`, we can opt-in to publishing build assets to the BAR.

@chcosta @mmitche PTAL