### PR TITLE
Re-enable APICompat for netstandard1.x/2.0

### DIFF
--- a/src/apicompat/netstandard/netstandard.depproj
+++ b/src/apicompat/netstandard/netstandard.depproj
@@ -4,6 +4,7 @@
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
     <TargetFramework Condition="'$(TargetFramework)'==''">netstandard2.0</TargetFramework>
     <OutputFolder>$(TargetFramework)</OutputFolder>
+    <OutputPath>$(RestoredRefRootPath)$(OutputFolder)</OutputPath>
     <RestoreOutputPath>$(IntermediateOutputPath)$(TargetFramework)</RestoreOutputPath>
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>
   </PropertyGroup>


### PR DESCRIPTION
This causes netstandard1.x/2.0 assets to be binplaced at `artifacts\obj\CompatShims\ref` again, which will re-enable the APICompat runs for those TFMs. @ViktorHofer I noticed you removed this line here: https://github.com/dotnet/standard/pull/1040/files#diff-1fea8681058f11db0ecbfc2fc8a5be52L7 - was that intentional?