### PR TITLE
Add missing dummy fields

### DIFF
--- a/src/netstandard/ref/System.Data.SqlTypes.cs
+++ b/src/netstandard/ref/System.Data.SqlTypes.cs
@@ -56,6 +56,7 @@ namespace System.Data.SqlTypes
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
     public partial struct SqlBoolean : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummyPrimitive;
         public static readonly System.Data.SqlTypes.SqlBoolean False;
         public static readonly System.Data.SqlTypes.SqlBoolean Null;
         public static readonly System.Data.SqlTypes.SqlBoolean One;
@@ -125,6 +126,7 @@ namespace System.Data.SqlTypes
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
     public partial struct SqlByte : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummyPrimitive;
         public static readonly System.Data.SqlTypes.SqlByte MaxValue;
         public static readonly System.Data.SqlTypes.SqlByte MinValue;
         public static readonly System.Data.SqlTypes.SqlByte Null;


### PR DESCRIPTION
In ced9376c, we've added dummy fields for structs. Apparently, I missed these two in the diff.