### PR TITLE
Add netstandard.xml Intellisense file back to NetStandard.Library

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,7 +84,12 @@
     <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
   </PropertyGroup>
 
-   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- Redefine this here so that it can be picked up by GetFilesToPackage -->
+  <PropertyGroup>
+    <XmlDocFileRoot>$(PackagesDir)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netstandard</XmlDocFileRoot>
+  </PropertyGroup>
 
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>


### PR DESCRIPTION
The SDK expects `XmlDocFileRoot` to be defined by the repo so that it can find the intellisense file to binplace into the package - redefining this property makes it so we get `netstandard.xml` in the package again for 2.1.

CC @dsplaisted @terrajobst 