### PR TITLE
Add transport package for NetStandard

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -9,5 +9,11 @@
         "Description": "A set of standard .NET APIs that are prescribed to be used and supported together.",
         "CommonTypes": [
         ]
+    },
+    {
+        "Name": "Microsoft.Private.Standard",
+        "Description": "A transport package for moving .NET Standard assets between repos",
+        "CommonTypes": [
+        ]
     }
 ]

--- a/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
+++ b/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
@@ -24,7 +24,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Target Name="ModifyTestItemGroup" AfterTargets="GetPackageFiles">
+  <Target Name="ModifyPackageFilePaths" AfterTargets="GetPackageFiles">
     <!-- Modify PackageFile TargetPaths-->
     <ItemGroup>
       <PackageFile Condition="'%(PackageFile.TargetPath)' != ''">

--- a/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
+++ b/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
@@ -28,7 +28,7 @@
     <!-- Modify PackageFile TargetPaths-->
     <ItemGroup>
       <PackageFile Condition="'%(PackageFile.TargetPath)' != ''">
-        <TargetPath >ref/$(NETStandardVersion)</TargetPath>
+        <TargetPath>ref/$(NETStandardVersion)</TargetPath>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
+++ b/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <Version>2.1.0</Version>
+    <HarvestStablePackage>false</HarvestStablePackage>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <OmitDependencies>true</OmitDependencies>
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <NETStandardVersion>netstandard2.1</NETStandardVersion>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <Import Project="NETStandard.Library.dependencies.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\netstandard.csproj" />
+    <ProjectReference Include="shims\netstandard\dir.builds">
+      <Facade>true</Facade>
+    </ProjectReference>
+    <ProjectReference Include="shims\netfx\dir.builds">
+      <Facade>true</Facade>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Target Name="ModifyTestItemGroup" AfterTargets="GetPackageFiles">
+    <!-- Modify PackageFile TargetPaths-->
+    <ItemGroup>
+      <PackageFile Condition="'%(PackageFile.TargetPath)' != ''">
+        <TargetPath >ref/$(NETStandardVersion)</TargetPath>
+      </PackageFile>
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <OutDir>$(ArtifactsBinDir)shims/$(ShimRelOutputPath)</OutDir>
+  </PropertyGroup>
+
+</Project>

--- a/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
+++ b/src/netstandard/pkg/Microsoft.Private.Standard.pkgproj
@@ -12,8 +12,6 @@
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 
-  <Import Project="NETStandard.Library.dependencies.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\netstandard.csproj" />
     <ProjectReference Include="shims\netstandard\dir.builds">
@@ -34,9 +32,5 @@
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
-
-  <PropertyGroup>
-    <OutDir>$(ArtifactsBinDir)shims/$(ShimRelOutputPath)</OutDir>
-  </PropertyGroup>
 
 </Project>

--- a/src/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/src/netstandard/pkg/NETStandard.Library.pkgproj
@@ -59,8 +59,4 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
-  <PropertyGroup>
-    <OutDir>$(ArtifactsBinDir)shims/$(ShimRelOutputPath)</OutDir>
-  </PropertyGroup>
-
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -4,6 +4,7 @@
 
   <ItemGroup>
     <Project Include="netstandard\pkg\NETStandard.Library.pkgproj" />
+    <Project Include="netstandard\pkg\Microsoft.Private.Standard.pkgproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
This creates a transport package, `Microsoft.Private.Standard`, which contains the same netstandard2.1 binaries as `NetStandard.Library`, but not `NetStandard.Library.Targets`. The assets are in `ref\netstandard2.1` instead of `build\netstandard2.1\ref`. This transport package can be consumed by Core-Setup for the purpose of creating the targeting pack, rather than publicly shipping `NetStandard.Library`, or having Core-Setup consume its Standard dependencies through `NetStandard.Library`. Eventually we can phase out NS.L in favor of this transport package.

@ericstj @dagood @terrajobst PTAL

Resolves https://github.com/dotnet/standard/issues/1106