### PR TITLE
Fix Range.GetOffsetAndLength()

### DIFF
--- a/src/netstandard/ref/System.cs
+++ b/src/netstandard/ref/System.cs
@@ -3373,18 +3373,9 @@ namespace System
         public override bool Equals(object value) { throw null; }
         public bool Equals(System.Range other) { throw null; }
         public override int GetHashCode() { throw null; }
-        public System.Range.OffsetAndLength GetOffsetAndLength(int length) { throw null; }
+        public (int Offset, int Length) GetOffsetAndLength(int length) { throw null; }
         public static System.Range StartAt(System.Index start) { throw null; }
         public override string ToString() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public readonly partial struct OffsetAndLength
-        {
-            private readonly int _dummyPrimitive;
-            public OffsetAndLength(int offset, int length) { throw null; }
-            public int Length { get { throw null; } }
-            public int Offset { get { throw null; } }
-            public void Deconstruct(out int offset, out int length) { throw null; }
-        }
     }
     public partial class RankException : System.SystemException
     {


### PR DESCRIPTION
We ended up [agreeing](https://github.com/dotnet/corefx/issues/35508) that it's best to use tuples in cases like this.

***Note**: This isn't a breaking change in .NET Standard, as `Range` hasn't shipped yet.*