### PR TITLE
Remove finalizers

### DIFF
--- a/src/netstandard/ref/System.ComponentModel.Design.cs
+++ b/src/netstandard/ref/System.ComponentModel.Design.cs
@@ -124,7 +124,6 @@ namespace System.ComponentModel.Design
         public void Cancel() { }
         public void Commit() { }
         protected virtual void Dispose(bool disposing) { }
-        ~DesignerTransaction() { }
         protected abstract void OnCancel();
         protected abstract void OnCommit();
         void System.IDisposable.Dispose() { }

--- a/src/netstandard/ref/System.ComponentModel.cs
+++ b/src/netstandard/ref/System.ComponentModel.cs
@@ -314,7 +314,6 @@ namespace System.ComponentModel
         public event System.EventHandler Disposed { add { } remove { } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~Component() { }
         protected virtual object GetService(System.Type service) { throw null; }
         public override string ToString() { throw null; }
     }
@@ -353,7 +352,6 @@ namespace System.ComponentModel
         protected virtual System.ComponentModel.ISite CreateSite(System.ComponentModel.IComponent component, string name) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~Container() { }
         protected virtual object GetService(System.Type service) { throw null; }
         public virtual void Remove(System.ComponentModel.IComponent component) { }
         protected void RemoveWithoutUnsiting(System.ComponentModel.IComponent component) { }
@@ -1196,7 +1194,6 @@ namespace System.ComponentModel
         public event System.EventHandler Disposed { add { } remove { } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~MarshalByValueComponent() { }
         public virtual object GetService(System.Type service) { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/netstandard/ref/System.Diagnostics.Tracing.cs
+++ b/src/netstandard/ref/System.Diagnostics.Tracing.cs
@@ -166,7 +166,6 @@ namespace System.Diagnostics.Tracing
         public event System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs> EventCommandExecuted { add { } remove { } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~EventSource() { }
         public static string GenerateManifest(System.Type eventSourceType, string assemblyPathToIncludeInManifest) { throw null; }
         public static string GenerateManifest(System.Type eventSourceType, string assemblyPathToIncludeInManifest, System.Diagnostics.Tracing.EventManifestOptions flags) { throw null; }
         public static System.Guid GetGuid(System.Type eventSourceType) { throw null; }

--- a/src/netstandard/ref/System.IO.cs
+++ b/src/netstandard/ref/System.IO.cs
@@ -497,7 +497,6 @@ namespace System.IO
         public override System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(System.IAsyncResult asyncResult) { }
-        ~FileStream() { }
         public override void Flush() { }
         public virtual void Flush(bool flushToDisk) { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/netstandard/ref/System.Net.Sockets.cs
+++ b/src/netstandard/ref/System.Net.Sockets.cs
@@ -138,7 +138,6 @@ namespace System.Net.Sockets
         protected override void Dispose(bool disposing) { }
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(System.IAsyncResult asyncResult) { }
-        ~NetworkStream() { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int size) { throw null; }
@@ -315,7 +314,6 @@ namespace System.Net.Sockets
         public int EndSend(System.IAsyncResult asyncResult, out System.Net.Sockets.SocketError errorCode) { throw null; }
         public void EndSendFile(System.IAsyncResult asyncResult) { }
         public int EndSendTo(System.IAsyncResult asyncResult) { throw null; }
-        ~Socket() { }
         public object GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName) { throw null; }
         public void GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public byte[] GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionLength) { throw null; }
@@ -394,7 +392,6 @@ namespace System.Net.Sockets
         public object UserToken { get { throw null; } set { } }
         public event System.EventHandler<System.Net.Sockets.SocketAsyncEventArgs> Completed { add { } remove { } }
         public void Dispose() { }
-        ~SocketAsyncEventArgs() { }
         protected virtual void OnCompleted(System.Net.Sockets.SocketAsyncEventArgs e) { }
         public void SetBuffer(byte[] buffer, int offset, int count) { }
         public void SetBuffer(int offset, int count) { }
@@ -634,7 +631,6 @@ namespace System.Net.Sockets
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void EndConnect(System.IAsyncResult asyncResult) { }
-        ~TcpClient() { }
         public System.Net.Sockets.NetworkStream GetStream() { throw null; }
     }
     public partial class TcpListener

--- a/src/netstandard/ref/System.Runtime.ConstrainedExecution.cs
+++ b/src/netstandard/ref/System.Runtime.ConstrainedExecution.cs
@@ -20,7 +20,6 @@ namespace System.Runtime.ConstrainedExecution
     public abstract partial class CriticalFinalizerObject
     {
         protected CriticalFinalizerObject() { }
-        ~CriticalFinalizerObject() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Method, Inherited=false)]
     public sealed partial class PrePrepareMethodAttribute : System.Attribute

--- a/src/netstandard/ref/System.Runtime.InteropServices.cs
+++ b/src/netstandard/ref/System.Runtime.InteropServices.cs
@@ -215,7 +215,6 @@ namespace System.Runtime.InteropServices
         public void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~CriticalHandle() { }
         protected abstract bool ReleaseHandle();
         protected void SetHandle(System.IntPtr handle) { }
         public void SetHandleAsInvalid() { }
@@ -843,7 +842,6 @@ namespace System.Runtime.InteropServices
         public void DangerousRelease() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~SafeHandle() { }
         protected abstract bool ReleaseHandle();
         protected void SetHandle(System.IntPtr handle) { }
         public void SetHandleAsInvalid() { }

--- a/src/netstandard/ref/System.Security.Cryptography.cs
+++ b/src/netstandard/ref/System.Security.Cryptography.cs
@@ -513,7 +513,6 @@ namespace System.Security.Cryptography
         public void Clear() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~FromBase64Transform() { }
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) { throw null; }
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) { throw null; }
     }
@@ -1226,7 +1225,6 @@ namespace System.Security.Cryptography
         public void Clear() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~ToBase64Transform() { }
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) { throw null; }
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) { throw null; }
     }

--- a/src/netstandard/ref/System.Threading.cs
+++ b/src/netstandard/ref/System.Threading.cs
@@ -650,7 +650,6 @@ namespace System.Threading
         public System.Collections.Generic.IList<T> Values { get { throw null; } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        ~ThreadLocal() { }
         public override string ToString() { throw null; }
     }
     public static partial class ThreadPool

--- a/src/netstandard/ref/System.cs
+++ b/src/netstandard/ref/System.cs
@@ -5258,7 +5258,6 @@ namespace System
         public virtual bool IsAlive { get { throw null; } }
         public virtual object Target { get { throw null; } set { } }
         public virtual bool TrackResurrection { get { throw null; } }
-        ~WeakReference() { }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed partial class WeakReference<T> : System.Runtime.Serialization.ISerializable where T : class


### PR DESCRIPTION
My understanding from earlier discussions with @jkotas and @marek-safar was that we should treat finalizers as an implementation detail of the platform that implements .NET Standard. Thus, I've changed my diffing to generally exclude all finalizers. This PR updates the reference assembly to match it.

@jkotas / @marek-safar: I assume you're OK with that?