### PR TITLE
Prevent non-framework code from extending BaseNumberConverter

### DIFF
--- a/src/netstandard/ref/System.ComponentModel.cs
+++ b/src/netstandard/ref/System.ComponentModel.cs
@@ -118,7 +118,7 @@ namespace System.ComponentModel
     }
     public abstract partial class BaseNumberConverter : System.ComponentModel.TypeConverter
     {
-        protected BaseNumberConverter() { }
+        internal BaseNumberConverter() { }
         public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { throw null; }
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { throw null; }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { throw null; }


### PR DESCRIPTION
This fixes #1171.

Please note that this is technically an API breaking change (we shipped `BaseNumberConverter` in .NET Standard 2.0 with a protected constructor, which was mistake). But there is no way to derive and instantiate this class. An exception will get thrown if you try to instantiate the derived class. 

For more details, see https://github.com/dotnet/corefx/pull/37278.

/cc @ericstj 