### PR TITLE
Fix official build which is failing when trying to publish the packages to BAR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,14 +22,12 @@ jobs:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
     enablePublishTestResults: false
+    enablePublishBuildAssets: true
     enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: dotnet/standard
     jobs:
     - job: Windows_NT
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        parameters:
-          enablePublishBuildAssets: true
       pool: 
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCorePublic-Int-Pool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,14 @@ jobs:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
     enablePublishTestResults: false
-    enablePublishBuildAssets: true
     enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: dotnet/standard
     jobs:
     - job: Windows_NT
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        parameters:
+          enablePublishBuildAssets: true
       pool: 
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCorePublic-Int-Pool
@@ -71,6 +73,7 @@ jobs:
       - script: build.cmd
           -configuration $(_BuildConfig) 
           -prepareMachine
+          -publish
           -ci
           -warnaserror:0
           $(_BuildArgs)


### PR DESCRIPTION
cc: @wtgodbe 

Official builds are failing when trying to publish packages to BAR because the AssetsManifest file isn't being generated any longer. This was caused because of a breaking change in Arcade. These changes will fix this issue.