### PR TITLE
Fail CI build if APICompat baseline files would change

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,6 +72,7 @@
     <OutputType>Library</OutputType>
     <RunApiCompat>$(IsSourceProject)</RunApiCompat>
     <BaselineAllAPICompatError Condition="'$(BaselineAllAPICompatError)' == ''">true</BaselineAllAPICompatError>
+    <BaselineAllAPICompatError Condition="'$(ContinuousIntegrationBuild)' == 'true'">false</BaselineAllAPICompatError>
     <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
   </PropertyGroup>
   

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,6 +71,7 @@
     <Platform>AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <RunApiCompat>$(IsSourceProject)</RunApiCompat>
+    <BaselineAllAPICompatError Condition="'$(BaselineAllAPICompatError)' == ''">true</BaselineAllAPICompatError>
     <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
   </PropertyGroup>
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,6 @@ jobs:
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            /p:BaselineAllAPICompatError=false
         - name: _OfficialBuildIdArgs
       # else
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -66,7 +65,6 @@ jobs:
           value: Test
         - name: _BuildArgs
           value: /p:SignType=$(_SignType)
-              /p:BaselineAllAPICompatError=false
       steps:
       - checkout: self
         clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            /p:BaselineAllAPICompatError=false
         - name: _OfficialBuildIdArgs
       # else
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -65,6 +66,7 @@ jobs:
           value: Test
         - name: _BuildArgs
           value: /p:SignType=$(_SignType)
+              /p:BaselineAllAPICompatError=false
       steps:
       - checkout: self
         clean: true

--- a/src/apicompat/apicompat.proj
+++ b/src/apicompat/apicompat.proj
@@ -207,7 +207,8 @@
       <ApiCompatArgs>$(ApiCompatArgs) --contract-depends "$(ApiCompatContracts)"</ApiCompatArgs>
       <ApiCompatArgs>$(ApiCompatArgs) --exclude-attributes "$(SourceDir)platforms\attributeExcludeList.txt"</ApiCompatArgs>
       <ApiCompatArgs>$(ApiCompatArgs) --impl-dirs "$(NetstandardRefPath),$(NetstandardShimsPath),$(NetfxShimsPath)"</ApiCompatArgs>
-      <ApiCompatBaselineAll>&gt; "$(ApiCompatBaselineFile)"</ApiCompatBaselineAll>
+      <ApiCompatArgs Condition="'$(BaselineAllAPICompatError)' != 'true' and Exists('$(ApiCompatBaselineFile)')">$(ApiCompatArgs) --baseline "$(ApiCompatBaselineFile)"</ApiCompatArgs>
+      <ApiCompatBaselineAll Condition="'$(BaselineAllAPICompatError)' == 'true'">&gt; $(ApiCompatBaselineFile)</ApiCompatBaselineAll>
       <ApiCompatExitCode>0</ApiCompatExitCode>
     </PropertyGroup>
 

--- a/src/netstandard/src/netstandard.csproj
+++ b/src/netstandard/src/netstandard.csproj
@@ -14,7 +14,6 @@
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <RunApiCompatForSrc>true</RunApiCompatForSrc>
     <RunMatchingRefApiCompat>false</RunMatchingRefApiCompat>
-    <BaselineAllAPICompatError>true</BaselineAllAPICompatError>
     <ApiCompatBaseline>$(MSBuildProjectDirectory)\ApiCompatBaseline.$(TargetFramework).txt</ApiCompatBaseline>
     <NoWarn>$(NoWarn);618</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Currently, if a change in Arcade would cause changes in the APICompat baseline files, the baseline files are rewritten without throwing an error. If somebody makes such a change without checking in the changes to the APICompat baselines, the CI should fail. This change achieves that. Resolves https://github.com/dotnet/standard/issues/1184.

@ericstj @terrajobst PTAL