### PR TITLE
Fix public key of ns2.0 shims

### DIFF
--- a/src/netstandard/pkg/shims/netstandard/System.Buffers.csproj
+++ b/src/netstandard/pkg/shims/netstandard/System.Buffers.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>System.Buffers</AssemblyName>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Buffers.Forwards.cs" />

--- a/src/netstandard/pkg/shims/netstandard/System.Memory.csproj
+++ b/src/netstandard/pkg/shims/netstandard/System.Memory.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>System.Memory</AssemblyName>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Memory.Forwards.cs" />

--- a/src/netstandard/pkg/shims/netstandard/System.Threading.Tasks.Extensions.csproj
+++ b/src/netstandard/pkg/shims/netstandard/System.Threading.Tasks.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>System.Threading.Tasks.Extensions</AssemblyName>
     <AssemblyVersion>4.2.1.0</AssemblyVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Tasks.Extensions.Forwards.cs" />


### PR DESCRIPTION
System.Buffers, System.Memory, and System.Threading.Tasks.Extensions all use
the open key.  Ensure we use the same key here.