### PR TITLE
 Remove myget dotnet-core feed from restore sources in Versions.props

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/sourcelink/api/v3/index.json;
       $(RestoreSources)
     </RestoreSources>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/sourcelink/api/v3/index.json;
       $(RestoreSources)
     </RestoreSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,6 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
It isn't needed as we can restore everything from dotnetfeed.

CC @ericstj @riarenas 