### PR TITLE
Adds attribution for APIs previously special-cased by the compiler

### DIFF
--- a/src/netstandard/ref/System.Diagnostics.Contracts.cs
+++ b/src/netstandard/ref/System.Diagnostics.Contracts.cs
@@ -9,16 +9,16 @@ namespace System.Diagnostics.Contracts
         public static event System.EventHandler<System.Diagnostics.Contracts.ContractFailedEventArgs> ContractFailed { add { } remove { } }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition) { }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition, string userMessage) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition, string userMessage) { }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assume(bool condition) { }
+        public static void Assume([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition) { }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assume(bool condition, string userMessage) { }
+        public static void Assume([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition, string userMessage) { }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         public static void EndContractBlock() { }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]

--- a/src/netstandard/ref/System.Diagnostics.cs
+++ b/src/netstandard/ref/System.Diagnostics.cs
@@ -41,17 +41,19 @@ namespace System.Diagnostics
 // Removed to break dependency on the larger TraceListener set of APIs
 //        public static System.Diagnostics.TraceListenerCollection Listeners { get { throw null; } }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition, string message) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition, string message) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition, string message, string detailMessage) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition, string message, string detailMessage) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert(bool condition, string message, string detailMessageFormat, params object[] args) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)]bool condition, string message, string detailMessageFormat, params object[] args) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Close() { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Fail(string message) { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Fail(string message, string detailMessage) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]

--- a/src/netstandard/ref/System.Runtime.ExceptionServices.cs
+++ b/src/netstandard/ref/System.Runtime.ExceptionServices.cs
@@ -9,7 +9,9 @@ namespace System.Runtime.ExceptionServices
         internal ExceptionDispatchInfo() { }
         public System.Exception SourceException { get { throw null; } }
         public static System.Runtime.ExceptionServices.ExceptionDispatchInfo Capture(System.Exception source) { throw null; }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public void Throw() { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public static void Throw(System.Exception source) { }
     }
     public partial class FirstChanceExceptionEventArgs : System.EventArgs

--- a/src/netstandard/ref/System.cs
+++ b/src/netstandard/ref/System.cs
@@ -2167,9 +2167,12 @@ namespace System
         public static string UserName { get { throw null; } }
         public static System.Version Version { get { throw null; } }
         public static long WorkingSet { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public static void Exit(int exitCode) { }
         public static string ExpandEnvironmentVariables(string name) { throw null; }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public static void FailFast(string message) { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public static void FailFast(string message, System.Exception exception) { }
         public static string[] GetCommandLineArgs() { throw null; }
         public static string GetEnvironmentVariable(string variable) { throw null; }
@@ -3769,8 +3772,8 @@ namespace System
         public static System.String IsInterned(System.String str) { throw null; }
         public bool IsNormalized() { throw null; }
         public bool IsNormalized(System.Text.NormalizationForm normalizationForm) { throw null; }
-        public static bool IsNullOrEmpty(System.String value) { throw null; }
-        public static bool IsNullOrWhiteSpace(System.String value) { throw null; }
+        public static bool IsNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(false)]System.String value) { throw null; }
+        public static bool IsNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(false)]System.String value) { throw null; }
         public static System.String Join(char separator, params object[] values) { throw null; }
         public static System.String Join(char separator, params string[] value) { throw null; }
         public static System.String Join(char separator, string[] value, int startIndex, int count) { throw null; }


### PR DESCRIPTION
This applies some of the nullable attributes for APIs that were previously special-cased by the compiler. The attribution is very basic only includes cases where we'e a 100% certain that these are never going to change.

I've arrived here by diffing CoreFX and .NET Standard using the following approach:

**Included**

* `DoesNotReturn`
* `DoesNotReturnIf`

**Considered**

* `NotNullWhen`

**Excluded**

* `MaybeNullWhenAttribute`
* `MaybeNullAttribute`
* `AllowNullAttribute`
* `DisallowNullAttribute`
* `NotNullAttribute`
* `NotNullIfNotNullAttribute`

@stephentoub @jcouv @dotnet/nullablefc: Please double check my work here.