### PR TITLE
Upgrade the IntelliSense package version to 3.0 Preview 8 for netstandard xml

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   <!-- Xml doc package info, which we don't need to be updated by DARC -->
   <PropertyGroup>
     <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
-    <XmlDocPackageVersion>2.0.0-preview3-26209-0</XmlDocPackageVersion>
+    <XmlDocPackageVersion>3.0.0-preview8-190815-0</XmlDocPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NetStandardLibraryPackage>netstandard.library</NetStandardLibraryPackage>


### PR DESCRIPTION
This contains the doc drops for the latest .NET Standard 2.1 xml docs.

This is the version currently referenced by corefx as well for the netcoreapp 3.0 xml docs: https://github.com/dotnet/corefx/blob/cf5c1b0a7c3cf0087ae72fd0e1995a274cfefe27/eng/Versions.props#L77

This likely needs to be merged into the release/3.0 branch as well. See https://github.com/dotnet/standard/pull/1448

cc @wtgodbe, @dagood, @carlossanlop, @terrajobst, @mairaw, @safern, @Anipik 