### PR TITLE
[release/3.0] Upgrade the IntelliSense package version to 3.0 Preview 8 for netstandard xml

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
   <!-- Xml doc package info, which we don't need to be updated by DARC -->
   <PropertyGroup>
     <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
-    <XmlDocPackageVersion>2.0.0-preview3-26209-0</XmlDocPackageVersion>
+    <XmlDocPackageVersion>3.0.0-preview8-190815-0</XmlDocPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NetStandardLibraryPackage>netstandard.library</NetStandardLibraryPackage>


### PR DESCRIPTION
Port of https://github.com/dotnet/standard/pull/1447

This contains the doc drops for the latest .NET Standard 2.1 xml docs.

cc @wtgodbe, @dagood, @carlossanlop, @terrajobst, @mairaw, @safern, @Anipik, @ericstj 