### PR TITLE
Enabling yaml stages for preview 9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,98 +16,108 @@ variables:
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
-jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableMicrobuild: true
-    enablePublishBuildArtifacts: true
-    enablePublishTestResults: false
-    enablePublishBuildAssets: true
-    enablePublishUsingPipelines: $(_PublishUsingPipelines)
-    enableTelemetry: true
-    helixRepo: dotnet/standard
-    jobs:
-    - job: Windows_NT
-      pool: 
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2017.open
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
-      variables:
-      # Enable signing for internal, non-PR builds
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - group: DotNet-Blob-Feed
-        - group: DotNet-Symbol-Server-Pats
-        - name: _SignType
-          value: Real
-        - name: _DotNetPublishToBlobFeed
-          value: true
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-            /p:DotNetSignType=$(_SignType)
-            /p:MicroBuild_SigningEnabled=true 
-            /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:TeamName=$(_TeamName)
-            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-            /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:DotNetPublishToBlobFeed=true
-            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        - name: _OfficialBuildIdArgs
-      # else
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Test
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-      steps:
-      - checkout: self
-        clean: true
-      - script: build.cmd
-          -configuration $(_BuildConfig) 
-          -prepareMachine
-          -sign
-          -publish
-          -ci
-          -warnaserror:0
-          $(_BuildArgs)
-        displayName: Windows Build / Publish
-
-    # Linux leg (only runs in CI)
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - job: Linux
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableTelemetry: true
+      helixRepo: dotnet/standard
+      jobs:
+      - job: Windows_NT
         pool: 
-          name: Hosted Ubuntu 1604
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: buildpool.windows.10.amd64.vs2017.open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: buildpool.windows.10.amd64.vs2017
         variables:
-        - name: _SignType
-          value: Test
+        # Enable signing for internal, non-PR builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - group: DotNet-Blob-Feed
+          - group: DotNet-Symbol-Server-Pats
+          - name: _SignType
+            value: Real
+          - name: _DotNetPublishToBlobFeed
+            value: true
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+              /p:DotNetSignType=$(_SignType)
+              /p:MicroBuild_SigningEnabled=true 
+              /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:TeamName=$(_TeamName)
+              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:DotNetPublishToBlobFeed=true
+              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _OfficialBuildIdArgs
+        # else
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Test
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
         steps:
         - checkout: self
           clean: true
-        - script: ./build.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-            --ci
-          displayName: Linux Build
+        - script: build.cmd
+            -configuration $(_BuildConfig) 
+            -prepareMachine
+            -sign
+            -publish
+            -ci
+            -warnaserror:0
+            $(_BuildArgs)
+          displayName: Windows Build / Publish
 
-    # OSX leg (only runs in CI)
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - job: OSX
-        pool: 
-          name: Hosted macOS
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./build.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-            --ci
-          displayName: OSX Build
+      # Linux leg (only runs in CI)
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - job: Linux
+          pool: 
+            name: Hosted Ubuntu 1604
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./build.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+              --ci
+            displayName: Linux Build
+
+      # OSX leg (only runs in CI)
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - job: OSX
+          pool: 
+            name: Hosted macOS
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./build.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+              --ci
+            displayName: OSX Build
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      # Symbol validation isn't being very reliable lately. This should be enabled back
+      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+      enableSymbolValidation: false


### PR DESCRIPTION
We require this change in order to propagate the dependecies updates for preview 9 branch.
related 3.0 change https://github.com/dotnet/standard/pull/1453

cc @mmitche 