### PR TITLE
Ask Mode: Add support for typed-datasets

### DIFF
--- a/src/netstandard/ref/System.Data.cs
+++ b/src/netstandard/ref/System.Data.cs
@@ -380,6 +380,29 @@ namespace System.Data
         public void Remove(System.Data.DataRow row) { }
         public void RemoveAt(int index) { }
     }
+    public static partial class DataRowComparer
+    {
+        public static System.Data.DataRowComparer<System.Data.DataRow> Default { get { throw null; } }
+    }
+    public sealed partial class DataRowComparer<TRow> : System.Collections.Generic.IEqualityComparer<TRow> where TRow : System.Data.DataRow
+    {
+        internal DataRowComparer() { }
+        public static System.Data.DataRowComparer<TRow> Default { get { throw null; } }
+        public bool Equals(TRow leftRow, TRow rightRow) { throw null; }
+        public int GetHashCode(TRow row) { throw null; }
+    }
+    public static partial class DataRowExtensions
+    {
+        public static T Field<T>(this System.Data.DataRow row, System.Data.DataColumn column) { throw null; }
+        public static T Field<T>(this System.Data.DataRow row, System.Data.DataColumn column, System.Data.DataRowVersion version) { throw null; }
+        public static T Field<T>(this System.Data.DataRow row, int columnIndex) { throw null; }
+        public static T Field<T>(this System.Data.DataRow row, int columnIndex, System.Data.DataRowVersion version) { throw null; }
+        public static T Field<T>(this System.Data.DataRow row, string columnName) { throw null; }
+        public static T Field<T>(this System.Data.DataRow row, string columnName, System.Data.DataRowVersion version) { throw null; }
+        public static void SetField<T>(this System.Data.DataRow row, System.Data.DataColumn column, T value) { }
+        public static void SetField<T>(this System.Data.DataRow row, int columnIndex, T value) { }
+        public static void SetField<T>(this System.Data.DataRow row, string columnName, T value) { }
+    }
     [System.FlagsAttribute]
     public enum DataRowState
     {
@@ -755,6 +778,15 @@ namespace System.Data
         public void Remove(string name, string tableNamespace) { }
         public void RemoveAt(int index) { }
     }
+    public static partial class DataTableExtensions
+    {
+        public static System.Data.DataView AsDataView(this System.Data.DataTable table) { throw null; }
+        public static System.Data.DataView AsDataView<T>(this System.Data.EnumerableRowCollection<T> source) where T : System.Data.DataRow { throw null; }
+        public static System.Data.EnumerableRowCollection<System.Data.DataRow> AsEnumerable(this System.Data.DataTable source) { throw null; }
+        public static System.Data.DataTable CopyToDataTable<T>(this System.Collections.Generic.IEnumerable<T> source) where T : System.Data.DataRow { throw null; }
+        public static void CopyToDataTable<T>(this System.Collections.Generic.IEnumerable<T> source, System.Data.DataTable table, System.Data.LoadOption options) where T : System.Data.DataRow { }
+        public static void CopyToDataTable<T>(this System.Collections.Generic.IEnumerable<T> source, System.Data.DataTable table, System.Data.LoadOption options, System.Data.FillErrorEventHandler errorHandler) where T : System.Data.DataRow { }
+    }
     public sealed partial class DataTableNewRowEventArgs : System.EventArgs
     {
         public DataTableNewRowEventArgs(System.Data.DataRow dataRow) { }
@@ -1043,6 +1075,31 @@ namespace System.Data
         public DuplicateNameException(string s) { }
         public DuplicateNameException(string message, System.Exception innerException) { }
     }
+    public abstract partial class EnumerableRowCollection : System.Collections.IEnumerable
+    {
+        internal EnumerableRowCollection() { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public partial class EnumerableRowCollection<TRow> : System.Data.EnumerableRowCollection, System.Collections.Generic.IEnumerable<TRow>, System.Collections.IEnumerable
+    {
+        internal EnumerableRowCollection() { }
+        public System.Collections.Generic.IEnumerator<TRow> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public static partial class EnumerableRowCollectionExtensions
+    {
+        public static System.Data.EnumerableRowCollection<TResult> Cast<TResult>(this System.Data.EnumerableRowCollection source) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderByDescending<TRow, TKey>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderByDescending<TRow, TKey>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderBy<TRow, TKey>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderBy<TRow, TKey>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) { throw null; }
+        public static System.Data.EnumerableRowCollection<S> Select<TRow, S>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, S> selector) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> ThenByDescending<TRow, TKey>(this System.Data.OrderedEnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> ThenByDescending<TRow, TKey>(this System.Data.OrderedEnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> ThenBy<TRow, TKey>(this System.Data.OrderedEnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector) { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> ThenBy<TRow, TKey>(this System.Data.OrderedEnumerableRowCollection<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) { throw null; }
+        public static System.Data.EnumerableRowCollection<TRow> Where<TRow>(this System.Data.EnumerableRowCollection<TRow> source, System.Func<TRow, bool> predicate) { throw null; }
+    }
     public partial class EvaluateException : System.Data.InvalidExpressionException
     {
         public EvaluateException() { }
@@ -1329,6 +1386,10 @@ namespace System.Data
         public NoNullAllowedException(string s) { }
         public NoNullAllowedException(string message, System.Exception innerException) { }
     }
+    public sealed partial class OrderedEnumerableRowCollection<TRow> : System.Data.EnumerableRowCollection<TRow>
+    {
+        internal OrderedEnumerableRowCollection() { }
+    }
     public enum ParameterDirection
     {
         Input = 1,
@@ -1446,6 +1507,25 @@ namespace System.Data
         protected SyntaxErrorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public SyntaxErrorException(string s) { }
         public SyntaxErrorException(string message, System.Exception innerException) { }
+    }
+    public abstract partial class TypedTableBase<T> : System.Data.DataTable, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : System.Data.DataRow
+    {
+        protected TypedTableBase() { }
+        protected TypedTableBase(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public System.Data.EnumerableRowCollection<TResult> Cast<TResult>() { throw null; }
+        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public static partial class TypedTableBaseExtensions
+    {
+        public static System.Data.EnumerableRowCollection<TRow> AsEnumerable<TRow>(this System.Data.TypedTableBase<TRow> source) where TRow : System.Data.DataRow { throw null; }
+        public static TRow ElementAtOrDefault<TRow>(this System.Data.TypedTableBase<TRow> source, int index) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderByDescending<TRow, TKey>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, TKey> keySelector) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderByDescending<TRow, TKey>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderBy<TRow, TKey>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, TKey> keySelector) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.OrderedEnumerableRowCollection<TRow> OrderBy<TRow, TKey>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, TKey> keySelector, System.Collections.Generic.IComparer<TKey> comparer) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.EnumerableRowCollection<S> Select<TRow, S>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, S> selector) where TRow : System.Data.DataRow { throw null; }
+        public static System.Data.EnumerableRowCollection<TRow> Where<TRow>(this System.Data.TypedTableBase<TRow> source, System.Func<TRow, bool> predicate) where TRow : System.Data.DataRow { throw null; }
     }
     [System.ComponentModel.DefaultPropertyAttribute("ConstraintName")]
     public partial class UniqueConstraint : System.Data.Constraint

--- a/src/netstandard/src/ApiCompatBaseline.monoandroid.txt
+++ b/src/netstandard/src/ApiCompatBaseline.monoandroid.txt
@@ -296,9 +296,19 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.ToolboxItemAttribute' exists on 'System.Data.DataSet' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.PrepareAsync(System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
@@ -1036,4 +1046,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1037
+Total Issues: 1047

--- a/src/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/src/netstandard/src/ApiCompatBaseline.net461.txt
@@ -346,8 +346,18 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Data.Common.DbColumn' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
@@ -1197,4 +1207,4 @@ CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Xml.Sche
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlAnyAttributeAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the implementation.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlNamespaceDeclarationsAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the implementation.
 TypesMustExist : Type 'System.Xml.XPath.XDocumentExtensions' does not exist in the implementation but it does exist in the contract.
-Total Issues: 1198
+Total Issues: 1208

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
@@ -296,9 +296,19 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.ToolboxItemAttribute' exists on 'System.Data.DataSet' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.PrepareAsync(System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
@@ -1065,4 +1075,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1066
+Total Issues: 1076

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
@@ -296,9 +296,19 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.ToolboxItemAttribute' exists on 'System.Data.DataSet' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.PrepareAsync(System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
@@ -1040,4 +1050,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1041
+Total Issues: 1051

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
@@ -296,9 +296,19 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.ToolboxItemAttribute' exists on 'System.Data.DataSet' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.PrepareAsync(System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
@@ -1065,4 +1075,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1066
+Total Issues: 1076

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
@@ -296,9 +296,19 @@ CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAtt
 TypeCannotChangeClassification : Type 'System.ComponentModel.Design.Serialization.MemberRelationship' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute' changed from '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  https://go.microsoft.com/fwlink/?linkid=14202")]' in the contract to '[ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]' in the implementation.
 TypesMustExist : Type 'System.Data.DataReaderExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowComparer<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.DataRowExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.ToolboxItemAttribute' exists on 'System.Data.DataSet' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Data.DataSysDescriptionAttribute' changed from '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]' in the contract to '[ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  http://go.microsoft.com/fwlink/?linkid=14202", false)]' in the implementation.
+TypesMustExist : Type 'System.Data.DataTableExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.DataTableReader' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.EnumerableRowCollectionExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.OrderedEnumerableRowCollection<TRow>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBase<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Data.TypedTableBaseExtensions' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Data.Common.DbCommand' does not implement interface 'System.IAsyncDisposable' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.DisposeAsync()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Data.Common.DbCommand.PrepareAsync(System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
@@ -1065,4 +1075,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1066
+Total Issues: 1076


### PR DESCRIPTION
## Description

.NET Core 3.0 has full support for `System.Data.DataTableExtensions` which also enables the visual `DataSet` designer in Visual Studio. However, .NET Standard 2.1 only supported a subset which makes the code that is generated by the designer not compile in .NET Standard 2.1. The fix is include the missing APIs in .NET Standard 2.1.

This requires no changes in .NET Core 3.0 but will require minimal work in platforms implementing .NET Standard 2.1, most notably Mono/Xamarin. However, they already signed off on it.

## Customer Impact

Customer will be able to use the DataSet designer in .NET Standard libraries, which will become handy as people port their existing .NET Framework desktop applications to .NET Core 3.0.

## Regression?

No.

## Risk

Low. All APIs are already implemented in .NET Core 3.0.