### PR TITLE
Expose SequenceReader<T> and friends

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
     <RunApiCompat>$(IsSourceProject)</RunApiCompat>
     <BaselineAllAPICompatError Condition="'$(BaselineAllAPICompatError)' == ''">true</BaselineAllAPICompatError>
     <BaselineAllAPICompatError Condition="'$(ContinuousIntegrationBuild)' == 'true'">false</BaselineAllAPICompatError>
-    <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
+    <LangVersion>preview</LangVersion> <!-- default to allowing all language features -->
   </PropertyGroup>
   
   <!-- Redefine this here so that it can be picked up by GetFilesToPackage -->

--- a/src/netstandard/ref/System.Buffers.cs
+++ b/src/netstandard/ref/System.Buffers.cs
@@ -4,6 +4,20 @@
 
 namespace System.Buffers
 {
+    public sealed partial class ArrayBufferWriter<T> : System.Buffers.IBufferWriter<T>
+    {
+        public ArrayBufferWriter() { }
+        public ArrayBufferWriter(int initialCapacity) { }
+        public int Capacity { get { throw null; } }
+        public int FreeCapacity { get { throw null; } }
+        public int WrittenCount { get { throw null; } }
+        public System.ReadOnlyMemory<T> WrittenMemory { get { throw null; } }
+        public System.ReadOnlySpan<T> WrittenSpan { get { throw null; } }
+        public void Advance(int count) { }
+        public void Clear() { }
+        public System.Memory<T> GetMemory(int sizeHint = 0) { throw null; }
+        public System.Span<T> GetSpan(int sizeHint = 0) { throw null; }
+    }
     public abstract partial class ArrayPool<T>
     {
         protected ArrayPool() { }
@@ -85,6 +99,7 @@ namespace System.Buffers
         public ReadOnlySequence(T[] array, int start, int length) { throw null; }
         public System.SequencePosition End { get { throw null; } }
         public System.ReadOnlyMemory<T> First { get { throw null; } }
+        public System.ReadOnlySpan<T> FirstSpan { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public bool IsSingleSegment { get { throw null; } }
         public long Length { get { throw null; } }
@@ -106,7 +121,6 @@ namespace System.Buffers
         public partial struct Enumerator
         {
             private object _dummy;
-            private int _dummyPrimitive;
             public Enumerator(in System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
             public System.ReadOnlyMemory<T> Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -120,6 +134,51 @@ namespace System.Buffers
         public long RunningIndex { get { throw null; } protected set { } }
     }
     public delegate void ReadOnlySpanAction<T, in TArg>(System.ReadOnlySpan<T> span, TArg arg);
+    public ref partial struct SequenceReader<T> where T : unmanaged, System.IEquatable<T>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public SequenceReader(System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
+        public readonly long Consumed { get { throw null; } }
+        public readonly System.ReadOnlySpan<T> CurrentSpan { get { throw null; } }
+        public readonly int CurrentSpanIndex { get { throw null; } }
+        public readonly bool End { get { throw null; } }
+        public readonly long Length { get { throw null; } }
+        public readonly System.SequencePosition Position { get { throw null; } }
+        public readonly long Remaining { get { throw null; } }
+        public readonly System.Buffers.ReadOnlySequence<T> Sequence { get { throw null; } }
+        public readonly System.ReadOnlySpan<T> UnreadSpan { get { throw null; } }
+        public void Advance(long count) { }
+        public long AdvancePast(T value) { throw null; }
+        public long AdvancePastAny(System.ReadOnlySpan<T> values) { throw null; }
+        public long AdvancePastAny(T value0, T value1) { throw null; }
+        public long AdvancePastAny(T value0, T value1, T value2) { throw null; }
+        public long AdvancePastAny(T value0, T value1, T value2, T value3) { throw null; }
+        public bool IsNext(System.ReadOnlySpan<T> next, bool advancePast = false) { throw null; }
+        public bool IsNext(T next, bool advancePast = false) { throw null; }
+        public void Rewind(long count) { }
+        public bool TryAdvanceTo(T delimiter, bool advancePastDelimiter = true) { throw null; }
+        public bool TryAdvanceToAny(System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
+        public readonly bool TryCopyTo(System.Span<T> destination) { throw null; }
+        public readonly bool TryPeek(out T value) { throw null; }
+        public bool TryRead(out T value) { throw null; }
+        public bool TryReadTo(out System.Buffers.ReadOnlySequence<T> sequence, System.ReadOnlySpan<T> delimiter, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadTo(out System.Buffers.ReadOnlySequence<T> sequence, T delimiter, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadTo(out System.Buffers.ReadOnlySequence<T> sequence, T delimiter, T delimiterEscape, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadTo(out System.ReadOnlySpan<T> span, T delimiter, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadTo(out System.ReadOnlySpan<T> span, T delimiter, T delimiterEscape, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadToAny(out System.Buffers.ReadOnlySequence<T> sequence, System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
+        public bool TryReadToAny(out System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
+    }
+    public static partial class SequenceReaderExtensions
+    {
+        public static bool TryReadBigEndian(this ref System.Buffers.SequenceReader<byte> reader, out short value) { throw null; }
+        public static bool TryReadBigEndian(this ref System.Buffers.SequenceReader<byte> reader, out int value) { throw null; }
+        public static bool TryReadBigEndian(this ref System.Buffers.SequenceReader<byte> reader, out long value) { throw null; }
+        public static bool TryReadLittleEndian(this ref System.Buffers.SequenceReader<byte> reader, out short value) { throw null; }
+        public static bool TryReadLittleEndian(this ref System.Buffers.SequenceReader<byte> reader, out int value) { throw null; }
+        public static bool TryReadLittleEndian(this ref System.Buffers.SequenceReader<byte> reader, out long value) { throw null; }
+    }
     public delegate void SpanAction<T, in TArg>(System.Span<T> span, TArg arg);
     public readonly partial struct StandardFormat : System.IEquatable<System.Buffers.StandardFormat>
     {
@@ -140,5 +199,6 @@ namespace System.Buffers
         public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
         public static System.Buffers.StandardFormat Parse(string format) { throw null; }
         public override string ToString() { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> format, out System.Buffers.StandardFormat result) { throw null; }
     }
 }

--- a/src/netstandard/ref/System.Runtime.InteropServices.cs
+++ b/src/netstandard/ref/System.Runtime.InteropServices.cs
@@ -863,6 +863,7 @@ namespace System.Runtime.InteropServices
         public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> segment) { throw null; }
         public static bool TryGetReadOnlyMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ReadOnlyMemory<T> memory) { throw null; }
         public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.ReadOnlySequenceSegment<T> startSegment, out int startIndex, out System.Buffers.ReadOnlySequenceSegment<T> endSegment, out int endIndex) { throw null; }
+        public static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T value) where T : unmanaged { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited=false)]
     public sealed partial class StructLayoutAttribute : System.Attribute

--- a/src/netstandard/src/ApiCompatBaseline.monoandroid.txt
+++ b/src/netstandard/src/ApiCompatBaseline.monoandroid.txt
@@ -259,6 +259,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -270,6 +271,8 @@ TypesMustExist : Type 'System.Buffers.MemoryPool<T>' does not exist in the imple
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1046,4 +1049,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1047
+Total Issues: 1050

--- a/src/netstandard/src/ApiCompatBaseline.net461.txt
+++ b/src/netstandard/src/ApiCompatBaseline.net461.txt
@@ -285,6 +285,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -297,6 +298,8 @@ TypesMustExist : Type 'System.Buffers.OperationStatus' does not exist in the imp
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1207,4 +1210,4 @@ CannotChangeAttribute : Attribute 'System.ObsoleteAttribute' on 'System.Xml.Sche
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlAnyAttributeAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the implementation.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlNamespaceDeclarationsAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the implementation.
 TypesMustExist : Type 'System.Xml.XPath.XDocumentExtensions' does not exist in the implementation but it does exist in the contract.
-Total Issues: 1208
+Total Issues: 1211

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.ios.txt
@@ -259,6 +259,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -270,6 +271,8 @@ TypesMustExist : Type 'System.Buffers.MemoryPool<T>' does not exist in the imple
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1075,4 +1078,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1076
+Total Issues: 1079

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.mac.txt
@@ -259,6 +259,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -270,6 +271,8 @@ TypesMustExist : Type 'System.Buffers.MemoryPool<T>' does not exist in the imple
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1050,4 +1053,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1051
+Total Issues: 1054

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.tvos.txt
@@ -259,6 +259,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -270,6 +271,8 @@ TypesMustExist : Type 'System.Buffers.MemoryPool<T>' does not exist in the imple
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1075,4 +1078,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1076
+Total Issues: 1079

--- a/src/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
+++ b/src/netstandard/src/ApiCompatBaseline.xamarin.watchos.txt
@@ -259,6 +259,7 @@ MembersMustExist : Member 'System.Version.Parse(System.ReadOnlySpan<System.Char>
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryFormat(System.Span<System.Char>, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Version.TryParse(System.ReadOnlySpan<System.Char>, System.Version)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.ArrayBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ArrayPool<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.BuffersExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.IBufferWriter<T>' does not exist in the implementation but it does exist in the contract.
@@ -270,6 +271,8 @@ TypesMustExist : Type 'System.Buffers.MemoryPool<T>' does not exist in the imple
 TypesMustExist : Type 'System.Buffers.ReadOnlySequence<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySequenceSegment<T>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.ReadOnlySpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReader<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Buffers.SequenceReaderExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.SpanAction<T, TArg>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.StandardFormat' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Buffers.Binary.BinaryPrimitives' does not exist in the implementation but it does exist in the contract.
@@ -1075,4 +1078,4 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xm
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlChoiceIdentifierAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]' in the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Xml.Serialization.XmlSchemaImporter' does not inherit from base type 'System.Xml.Serialization.SchemaImporter' in the implementation but it does in the contract.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'System.Xml.Serialization.XmlSerializerAssemblyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct)]' in the implementation.
-Total Issues: 1076
+Total Issues: 1079


### PR DESCRIPTION
***Ask Mode 3.0 GA: Expose SequenceReader<T> in .NET Standard 2.1***

### Description

For ASP.NET pipelines we've added a type called `SequenceReader` that allows efficient traversal of data that is stored in multiple buffers. It's a key exchange type for low-level code. Unfortunately, we missed this API when adding new .NET Core 3.0 concepts to .NET Standard 2.1. This PR addresses that.

### Customer Impact

From @davidfowl:

> its damn near impossible to write efficient code that works well without the `SequenceReader`. The options today lead you to writing something very similar or converting the `ReadOnlySequence<T>` to `T[]` (which defeats the purpose).

### How found

Reported by customer.

### Regression?

No

### Risk

Risk is very small. .NET Standard just exposed the API that already exists in .NET Core.
