### PR TITLE
Setting version suffix as non empty for building release package versions

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -76,4 +76,8 @@
       <FileWrites Include="$(AssemblyInfoFile)" />
     </ItemGroup>
   </Target>
+
+  <PropertyGroup Condition="'$(DotNetFinalVersionKind)' == 'release'">
+    <VersionSuffix>$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
+  </PropertyGroup>
 </Project>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -314,7 +314,8 @@
     "NETStandard.Library": {
       "StableVersions": [
         "1.6.0",
-        "1.6.1"
+        "1.6.1",
+        "2.0.0"
       ],
       "BaselineVersion": "2.0.0",
       "InboxOn": {}

--- a/src/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/src/netstandard/pkg/NETStandard.Library.pkgproj
@@ -58,6 +58,12 @@
                       Overwrite="true" />
   </Target>
 
+  <Target Name="SetStableVersion" BeforeTargets="CalculatePackageVersion" Condition="'$(DotNetFinalVersionKind)' == 'release'">
+    <PropertyGroup>
+      <StableVersion>9.9.9</StableVersion>
+    </PropertyGroup>
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
 </Project>


### PR DESCRIPTION
Currently we get this error while building the release version of this package
```
C:\Users\mmitche\.nuget\packages\microsoft.dotnet.build.tasks.packaging\1.0.0-beta.19460.3\build\Packaging.targets(736,5): error : No VersionSuffix was set. Ensure 
it is set before targets in packaging are ran. [C:\enlistments\standard\src\netstandard\pkg\NETStandard.Library.pkgproj]
```

setting stableversion skips this task ApplyPreReleaseSuffix. we don't want to apply any suffix in release build.

we are applying this prefix to the dependencies of the package(GetNuGetPackageDependencies), but as its just a transport package, it should not matter. I was not able to find a good way to tackle this.

@ericstj any suggestions will be welcomed.