### PR TITLE
Source-build improvements.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -9,7 +9,7 @@
     <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
     <SignPackages Condition="'$(SignPackages)'==''">false</SignPackages>
 
-    <BuildDependsOn Condition="'$(BuildRestore)'=='true' and '$(DotNetBuildFromSource)'!='true'">$(BuildDependsOn);Restore</BuildDependsOn>
+    <BuildDependsOn Condition="'$(BuildRestore)'=='true'">$(BuildDependsOn);Restore</BuildDependsOn>
     <BuildDependsOn Condition="'$(BuildManaged)'=='true'">$(BuildDependsOn);BuildManaged</BuildDependsOn>
     <BuildDependsOn Condition="'$(BuildTests)'=='true' and '$(DotNetBuildFromSource)'!='true'">$(BuildDependsOn);Test</BuildDependsOn>
     <BuildDependsOn Condition="'$(BuildPackages)'=='true'">$(BuildDependsOn);Pack</BuildDependsOn>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -16,6 +16,10 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" />
+
+    <!-- SourceLink -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!-- excluded from source build -->
@@ -26,10 +30,6 @@
 
     <!-- XML docs -->
     <PackageReference Include="$(XmlDocPackage)" Version="$(XmlDocPackageVersion)" />
-
-    <!-- SourceLink -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
 
     <!-- last NETStandard package for harvesting -->
     <PackageReference Include="$(NetStandardLibraryPackage)" Version="$(NetStandardLibraryPackageVersion)" ExcludeAssets="All" />

--- a/src/netstandard/pkg/NETStandard.Library.pkgproj
+++ b/src/netstandard/pkg/NETStandard.Library.pkgproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <Target Name="EnsureRestoredNetStandardAssets" BeforeTargets="GenerateNuSpec">
-    <Error Condition="'@(NetStandard20Files)' == ''AND '$(DotNetBuildFromSource)' != 'true'" Text="Could not find package assets for netstandard2.0"  />
+    <Error Condition="'@(NetStandard20Files)' == ''" Text="Could not find package assets for netstandard2.0"  />
   </Target>
 
   <Target Name="StampTargets" BeforeTargets="GenerateNuSpec">


### PR DESCRIPTION
- Always restore, even in source-build.  This is required so we get NETStandard.Library netstandard2.0 reference bits for inclusion in the NETStandard.Library we are building.
  - Also make this error out in source-build if it fails like it does in the standalone build.
- Sourcelink is now supported in source-build.

I'm still testing this out in source-build but does it look like what you were thinking of @ericstj?