### PR TITLE
Update netstandard2.1 platform support info

### DIFF
--- a/docs/versions/netstandard2.1.md
+++ b/docs/versions/netstandard2.1.md
@@ -9,7 +9,7 @@
 ## Platform Support
 
 * No longer supported on .NET Framework
-* .NET Core 3.0
+* .NET Core 3.x / .NET 5 / .NET 6
 * Mono 6.4
 * Xamarin.iOS 12.16
 * Xamarin.Mac 5.16

--- a/docs/versions/netstandard2.1.md
+++ b/docs/versions/netstandard2.1.md
@@ -9,7 +9,7 @@
 ## Platform Support
 
 * No longer supported on .NET Framework
-* .NET Core 3.x / .NET 5 / .NET 6
+* .NET Core 3.x / .NET 5 and later
 * Mono 6.4
 * Xamarin.iOS 12.16
 * Xamarin.Mac 5.16


### PR DESCRIPTION
Since there was .NET 3.0 and 3.1, I chanced it to .NET Core 3.x. I also added .NET 5 and .NET 6 since both support.