### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ stages:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - job: OSX
           pool: 
-            vmImage: macOS-latest
+            vmImage: macOS-10.14
           variables:
           - name: _SignType
             value: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,11 @@ stages:
       - job: Windows_NT
         pool: 
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCorePublic-Pool
-            queue: buildpool.windows.10.amd64.vs2017.open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - job: Linux
           pool: 
-            name: Hosted Ubuntu 1604
+            vmImage: ubuntu-latest
           variables:
           - name: _SignType
             value: Test
@@ -102,7 +102,7 @@ stages:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - job: OSX
           pool: 
-            name: Hosted macOS
+            vmImage: macOS-latest
           variables:
           - name: _SignType
             value: Test


### PR DESCRIPTION
We are moving to 1ES hosted pools. This PR update pipeline yaml to use new pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276
